### PR TITLE
fix同花顺链接

### DIFF
--- a/czsc/traders/advanced.py
+++ b/czsc/traders/advanced.py
@@ -79,7 +79,7 @@ class CzscAdvancedTrader:
             tab.add(t1, "{}信号表".format(freq))
 
         t2 = Table()
-        ths_ = [["同花顺F10",  "http://basic.10jqka.com.cn/{}".format(self.symbol[:6])]]
+        ths_ = [["同花顺F10",  "http://basic.10jqka.com.cn/{}".format(self.symbol[-6:])]]
         t2.add(["名称", "数据"], [[k, v] for k, v in self.s.items() if "_" not in k] + ths_)
         t2.set_global_opts(title_opts=ComponentTitleOpts(title="缠中说禅因子表", subtitle=""))
         tab.add(t2, "因子表")


### PR DESCRIPTION
原先的切片取值生成的链接是错的，类似http://basic.10jqka.com.cn/SHSE.6，修改后为http://basic.10jqka.com.cn/601633