### PR TITLE
chore(rust): rust-toolchain.toml 显式声明 components + profile

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "stable"
+channel    = "stable"
+components = ["rustfmt", "clippy"]
+profile    = "minimal"


### PR DESCRIPTION
## Summary

将 \`rust-toolchain.toml\` 从仅 \`channel = \"stable\"\` 扩展为：

\`\`\`toml
[toolchain]
channel    = \"stable\"
components = [\"rustfmt\", \"clippy\"]
profile    = \"minimal\"
\`\`\`

## 收益

- 新 contributor 用 \`rustup\` 同步工具链时自动拉 rustfmt + clippy，避免 \`cargo fmt\` / \`cargo clippy\` 因缺组件失败。
- \`profile = \"minimal\"\` 让 rustup 跳过 rust-docs 等大件（节省 ~300 MB），需要的 rustfmt/clippy 由上方 components 显式补回。

## 兼容性

| 场景 | 影响 |
|---|---|
| 已安装的 toolchain（含 puccinialin / 现有 rustup） | 不受影响，profile/components 只对**新装时**生效 |
| CI（\`dtolnay/rust-toolchain@stable\`） | 该 action 默认就装 rustfmt + clippy，components 是冗余但不冲突；profile 被该 action 忽略 |
| \`channel = \"stable\"\` 不变 | 不会改变实际拉到的 rustc 版本（仍是 latest stable） |

> 注：本 PR **不**修复「rustc 升版后 clippy 启用新 lint 让 CI 红」的问题（如 PR #313 遇到的 \`needless_borrow\`）。修复那个需要 pin 具体版本（如 \`channel = \"1.95\"\`），但 pin 后需要手动 bump，是另一个权衡。

## Test plan

- [x] 本地 \`rustup show active-toolchain\` 确认 toolchain 文件被正确解析
- [x] \`cargo fmt --version\` / \`cargo clippy --version\` 均可用
- [ ] CI Lint / Test / Build wheel 通过