### PR TITLE
feat(czsc-core): PyO3 enum 暴露 .name + 可哈希，对齐 Python enum.Enum

### DIFF
--- a/crates/czsc-core/src/objects/direction.rs
+++ b/crates/czsc-core/src/objects/direction.rs
@@ -13,7 +13,7 @@ use strum_macros::{AsRefStr, Display, EnumString};
 /// 方向
 #[cfg_attr(feature = "python", gen_stub_pyclass_enum)]
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "czsc._native"))]
-#[derive(Debug, Clone, Copy, PartialEq, EnumString, AsRefStr, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, AsRefStr, Display)]
 pub enum Direction {
     /// 向上
     #[strum(serialize = "向上")]
@@ -78,6 +78,24 @@ impl Direction {
                 Direction::Down => "Down",
             }
         )
+    }
+
+    /// 返回 Rust variant 名（"Up" / "Down"），对齐 Python `enum.Enum.name`。
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Direction::Up => "Up",
+            Direction::Down => "Down",
+        }
+    }
+
+    /// 显式实现 `__hash__`，原因见 freq.rs 中同名方法的说明。
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn __richcmp__(

--- a/crates/czsc-core/src/objects/freq.rs
+++ b/crates/czsc-core/src/objects/freq.rs
@@ -239,6 +239,49 @@ impl Freq {
         format!("Freq.{self:?}")
     }
 
+    /// 返回 Rust variant 名（"F30" / "D" / "Tick" / ...），
+    /// 对齐 Python `enum.Enum.name` 的习惯——便于在序列化、日志、
+    /// 配置文件里使用稳定且语言无关的英文标识符。
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Freq::Tick => "Tick",
+            Freq::F1 => "F1",
+            Freq::F2 => "F2",
+            Freq::F3 => "F3",
+            Freq::F4 => "F4",
+            Freq::F5 => "F5",
+            Freq::F6 => "F6",
+            Freq::F10 => "F10",
+            Freq::F12 => "F12",
+            Freq::F15 => "F15",
+            Freq::F20 => "F20",
+            Freq::F30 => "F30",
+            Freq::F60 => "F60",
+            Freq::F120 => "F120",
+            Freq::F240 => "F240",
+            Freq::F360 => "F360",
+            Freq::D => "D",
+            Freq::W => "W",
+            Freq::M => "M",
+            Freq::S => "S",
+            Freq::Y => "Y",
+        }
+    }
+
+    /// 用 derived `Hash` 暴露 `__hash__`：PyO3 不会自动从 Rust 端
+    /// `#[derive(Hash)]` 派生 Python `__hash__`，且一旦写了 `__richcmp__`
+    /// 又不显式给 `__hash__`，PyO3 会把 `__hash__` 显式设为 `None`，导致
+    /// 实例不可哈希（无法做 dict/set 的 key）。这里显式实现以恢复
+    /// 与 Python `enum.Enum` 一致的可哈希语义。
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+
     #[classattr]
     fn __members__(py: Python) -> PyResult<Py<PyAny>> {
         let dict = PyDict::new(py);

--- a/crates/czsc-core/src/objects/mark.rs
+++ b/crates/czsc-core/src/objects/mark.rs
@@ -7,6 +7,8 @@ use pyo3::pymethods;
 #[cfg(feature = "python")]
 use pyo3::types::PyAnyMethods;
 #[cfg(feature = "python")]
+use pyo3::{Bound, IntoPyObject, Py, PyAny, PyErr, PyResult, Python};
+#[cfg(feature = "python")]
 use pyo3_stub_gen::derive::gen_stub_pyclass_enum;
 #[cfg(feature = "python")]
 use pyo3_stub_gen::derive::gen_stub_pymethods;
@@ -14,7 +16,7 @@ use pyo3_stub_gen::derive::gen_stub_pymethods;
 /// 分型类型
 #[cfg_attr(feature = "python", gen_stub_pyclass_enum)]
 #[cfg_attr(feature = "python", pyclass(from_py_object, module = "czsc._native"))]
-#[derive(Debug, Clone, PartialEq, EnumString, AsRefStr, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EnumString, AsRefStr, Display)]
 pub enum Mark {
     /// 底分型
     #[strum(serialize = "底分型")]
@@ -28,6 +30,38 @@ pub enum Mark {
 #[cfg(feature = "python")]
 #[pymethods]
 impl Mark {
+    /// 支持深拷贝
+    fn __deepcopy__(&self, _memo: &Bound<PyAny>) -> PyResult<Self> {
+        Ok(self.clone())
+    }
+
+    /// 支持 pickle 序列化：参考 Direction 的实现，通过 `__reduce__`
+    /// 把实例还原成 `Mark("G")` / `Mark("D")` 的构造调用。
+    fn __reduce__(&self) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
+        Python::attach(|py| {
+            let cls = py.get_type::<Self>();
+            let args = match self {
+                Mark::G => ("G",),
+                Mark::D => ("D",),
+            };
+            Ok((cls.into(), args.into_pyobject(py)?.into_any().unbind()))
+        })
+    }
+
+    /// 支持从字符串构造（接受 Rust variant 名或中文显示串）。
+    #[new]
+    fn new(value: &str) -> PyResult<Self> {
+        Ok(match value {
+            "G" | "顶分型" => Mark::G,
+            "D" | "底分型" => Mark::D,
+            _ => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Unknown mark value: {value}"
+                )));
+            }
+        })
+    }
+
     /// 获取标记的字符串值（与 czsc 库兼容）
     #[getter]
     fn value(&self) -> &'static str {
@@ -49,6 +83,26 @@ impl Mark {
                 Mark::D => "D",
             }
         )
+    }
+
+    /// 返回 Rust variant 名（"G" / "D"），对齐 Python `enum.Enum.name`。
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self {
+            Mark::G => "G",
+            Mark::D => "D",
+        }
+    }
+
+    /// 显式实现 `__hash__`，原因见 freq.rs 中同名方法的说明：PyO3 不会
+    /// 自动从 Rust `Hash` derive 派生 Python `__hash__`，且写了 `__richcmp__`
+    /// 后会把 `__hash__` 置 None。
+    fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn __richcmp__(

--- a/crates/czsc-core/src/objects/operate.rs
+++ b/crates/czsc-core/src/objects/operate.rs
@@ -21,7 +21,7 @@ use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 pub const ANY: &str = "任意";
 
 #[derive(
-    Clone, Copy, Debug, PartialEq, Hash, EnumString, EnumIter, AsRefStr, Serialize, Deserialize,
+    Clone, Copy, Debug, PartialEq, Eq, Hash, EnumString, EnumIter, AsRefStr, Serialize, Deserialize,
 )]
 pub enum Operate {
     /// 持多（Hold Long）
@@ -218,7 +218,10 @@ impl PyOperate {
     }
 
     fn __repr__(&self) -> String {
-        format!("PyOperate::{:?}", self.inner)
+        // 对齐 Python `enum.Enum` 的 `repr(EnumName.Variant) == "EnumName.Variant"` 约定，
+        // 也与 Freq / Mark / Direction 的 __repr__ 形式一致；
+        // 之前返回 "PyOperate::HL" 暴露了内部 Rust 结构名，是 pre-existing 不一致。
+        format!("Operate.{:?}", self.inner)
     }
 
     fn __eq__(&self, other: &Self) -> bool {
@@ -237,6 +240,22 @@ impl PyOperate {
     #[getter]
     fn value(&self) -> String {
         self.inner.to_chinese().to_string()
+    }
+
+    /// 返回 Rust variant 名（"HL" / "HS" / "HO" / "LO" / "LE" / "SO" / "SE"），
+    /// 对齐 Python `enum.Enum.name`：英文标识符稳定且与序列化路径
+    /// (`from_str` / `to_string`) 一致，适合做配置 key / 日志短码。
+    #[getter]
+    fn name(&self) -> &'static str {
+        match self.inner {
+            Operate::HL => "HL",
+            Operate::HS => "HS",
+            Operate::HO => "HO",
+            Operate::LO => "LO",
+            Operate::LE => "LE",
+            Operate::SO => "SO",
+            Operate::SE => "SE",
+        }
     }
 
     /// 支持pickle序列化

--- a/czsc/_native/__init__.pyi
+++ b/czsc/_native/__init__.pyi
@@ -716,6 +716,13 @@ class Operate:
         r"""
         兼容性属性：返回操作类型的中文字符串值
         """
+    @property
+    def name(self) -> builtins.str:
+        r"""
+        返回 Rust variant 名（"HL" / "HS" / "HO" / "LO" / "LE" / "SO" / "SE"），
+        对齐 Python `enum.Enum.name`：英文标识符稳定且与序列化路径
+        (`from_str` / `to_string`) 一致，适合做配置 key / 日志短码。
+        """
     @classmethod
     def hl(cls) -> Operate: ...
     @classmethod
@@ -1082,6 +1089,11 @@ class Direction(enum.Enum):
         r"""
         获取方向的字符串值（与 czsc 库兼容）
         """
+    @property
+    def name(self) -> builtins.str:
+        r"""
+        返回 Rust variant 名（"Up" / "Down"），对齐 Python `enum.Enum.name`。
+        """
     def __deepcopy__(self, _memo: typing.Any) -> Direction:
         r"""
         支持深拷贝
@@ -1093,6 +1105,10 @@ class Direction(enum.Enum):
     def __new__(cls, value: builtins.str) -> Direction: ...
     def __str__(self) -> builtins.str: ...
     def __repr__(self) -> builtins.str: ...
+    def __hash__(self) -> builtins.int:
+        r"""
+        显式实现 `__hash__`，原因见 freq.rs 中同名方法的说明。
+        """
     def __richcmp__(self, other: typing.Any, op: int) -> builtins.bool: ...
 
 @typing.final
@@ -1188,6 +1204,13 @@ class Freq(enum.Enum):
     __members__: typing.Any
     @property
     def value(self) -> builtins.str: ...
+    @property
+    def name(self) -> builtins.str:
+        r"""
+        返回 Rust variant 名（"F30" / "D" / "Tick" / ...），
+        对齐 Python `enum.Enum.name` 的习惯——便于在序列化、日志、
+        配置文件里使用稳定且语言无关的英文标识符。
+        """
     def __deepcopy__(self, _memo: typing.Any) -> Freq:
         r"""
         支持深拷贝
@@ -1199,6 +1222,14 @@ class Freq(enum.Enum):
     def __new__(cls, value: builtins.str) -> Freq: ...
     def __str__(self) -> builtins.str: ...
     def __repr__(self) -> builtins.str: ...
+    def __hash__(self) -> builtins.int:
+        r"""
+        用 derived `Hash` 暴露 `__hash__`：PyO3 不会自动从 Rust 端
+        `#[derive(Hash)]` 派生 Python `__hash__`，且一旦写了 `__richcmp__`
+        又不显式给 `__hash__`，PyO3 会把 `__hash__` 显式设为 `None`，导致
+        实例不可哈希（无法做 dict/set 的 key）。这里显式实现以恢复
+        与 Python `enum.Enum` 一致的可哈希语义。
+        """
     def __richcmp__(self, other: typing.Any, op: int) -> builtins.bool: ...
 
 @typing.final
@@ -1220,8 +1251,32 @@ class Mark(enum.Enum):
         r"""
         获取标记的字符串值（与 czsc 库兼容）
         """
+    @property
+    def name(self) -> builtins.str:
+        r"""
+        返回 Rust variant 名（"G" / "D"），对齐 Python `enum.Enum.name`。
+        """
+    def __deepcopy__(self, _memo: typing.Any) -> Mark:
+        r"""
+        支持深拷贝
+        """
+    def __reduce__(self) -> tuple[typing.Any, typing.Any]:
+        r"""
+        支持 pickle 序列化：参考 Direction 的实现，通过 `__reduce__`
+        把实例还原成 `Mark("G")` / `Mark("D")` 的构造调用。
+        """
+    def __new__(cls, value: builtins.str) -> Mark:
+        r"""
+        支持从字符串构造（接受 Rust variant 名或中文显示串）。
+        """
     def __str__(self) -> builtins.str: ...
     def __repr__(self) -> builtins.str: ...
+    def __hash__(self) -> builtins.int:
+        r"""
+        显式实现 `__hash__`，原因见 freq.rs 中同名方法的说明：PyO3 不会
+        自动从 Rust `Hash` derive 派生 Python `__hash__`，且写了 `__richcmp__`
+        后会把 `__hash__` 置 None。
+        """
     def __richcmp__(self, other: typing.Any, op: int) -> builtins.bool: ...
 
 @typing.final

--- a/tests/unit/test_native_enum_ergonomics.py
+++ b/tests/unit/test_native_enum_ergonomics.py
@@ -1,0 +1,153 @@
+"""PyO3 enum 在 Python 端的人体工学测试。
+
+覆盖 czsc 暴露的 4 个 enum 类型——``Freq`` / ``Mark`` / ``Direction`` /
+``Operate``——验证它们在 Python 端：
+
+1. 都可以哈希（``hash(x)`` 不抛、可作为 ``dict`` / ``set`` 的 key）；
+2. 都暴露 ``.name`` getter，返回 Rust variant 名（如 ``"F30"`` / ``"Up"`` / ``"HL"``），
+   对齐 Python ``enum.Enum.name`` 的习惯；
+3. ``.value`` getter 保留原有行为（返回中文显示串，向后兼容）；
+4. ``__hash__`` 与 ``__eq__`` 满足 Python 数据模型不变量：
+   ``a == b ⇒ hash(a) == hash(b)``；
+5. pickle 往返与 ``__richcmp__`` 行为不受影响。
+
+这套测试是 PyO3 enum 暴露层的 ratchet：将来若有人去掉 ``__hash__`` 或
+``name`` getter 而破坏多进程缓存 / dict 化场景，可在 CI 第一时间被拦下。
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from czsc import Direction, Freq, Mark, Operate
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(("Freq", Freq.F30, "F30", "30分钟"), id="Freq.F30"),
+        pytest.param(("Freq", Freq.D, "D", "日线"), id="Freq.D"),
+        pytest.param(("Freq", Freq.Tick, "Tick", "Tick"), id="Freq.Tick"),
+        pytest.param(("Mark", Mark.G, "G", "顶分型"), id="Mark.G"),
+        pytest.param(("Mark", Mark.D, "D", "底分型"), id="Mark.D"),
+        pytest.param(("Direction", Direction.Up, "Up", "向上"), id="Direction.Up"),
+        pytest.param(("Direction", Direction.Down, "Down", "向下"), id="Direction.Down"),
+        # Operate 7 个 variant 全覆盖：HL/HS/HO/LO/LE/SO/SE 的 name match arm
+        # 各自独立，必须逐个测，否则换 arm 顺序或 typo 不会被 CI 拦下。
+        pytest.param(("Operate", Operate.HL, "HL", "持多"), id="Operate.HL"),
+        pytest.param(("Operate", Operate.HS, "HS", "持空"), id="Operate.HS"),
+        pytest.param(("Operate", Operate.HO, "HO", "持币"), id="Operate.HO"),
+        pytest.param(("Operate", Operate.LO, "LO", "开多"), id="Operate.LO"),
+        pytest.param(("Operate", Operate.LE, "LE", "平多"), id="Operate.LE"),
+        pytest.param(("Operate", Operate.SO, "SO", "开空"), id="Operate.SO"),
+        pytest.param(("Operate", Operate.SE, "SE", "平空"), id="Operate.SE"),
+    ]
+)
+def enum_case(request):
+    return request.param
+
+
+def test_enum_has_name_attribute(enum_case):
+    """每个 enum 实例都暴露 ``.name``，返回 Rust variant 名。"""
+    _, member, expected_name, _ = enum_case
+    assert hasattr(member, "name"), f"{member!r} 缺少 .name getter"
+    assert member.name == expected_name
+
+
+def test_enum_preserves_value_attribute(enum_case):
+    """``.value`` getter 保持原有中文显示串语义，不被本次改动破坏。"""
+    _, member, _, expected_value = enum_case
+    assert member.value == expected_value
+
+
+def test_enum_is_hashable(enum_case):
+    """``hash(member)`` 不抛异常。"""
+    _, member, _, _ = enum_case
+    hash(member)  # 不抛即过
+
+
+def test_enum_usable_as_dict_key(enum_case):
+    """可作为 ``dict`` key，按变体身份去重。"""
+    _, member, _, _ = enum_case
+    bucket = {member: "x"}
+    assert bucket[member] == "x"
+
+
+def test_enum_usable_in_set_with_dedup():
+    """同一变体进集合应去重，不同变体保留。"""
+    s = {Freq.F30, Freq.F30, Freq.D}
+    assert len(s) == 2
+    assert Freq.F30 in s and Freq.D in s and Freq.F60 not in s
+
+    s2 = {Direction.Up, Direction.Up, Direction.Down}
+    assert len(s2) == 2
+
+    s3 = {Mark.G, Mark.G, Mark.D}
+    assert len(s3) == 2
+
+    s4 = {Operate.HL, Operate.HL, Operate.HS}
+    assert len(s4) == 2
+
+
+def test_hash_eq_invariant(enum_case):
+    """Python 数据模型不变量：``a == b ⇒ hash(a) == hash(b)``。
+
+    对相同 variant 的两个实例（在 Rust 端可能是同一份 ``Copy`` 也可能是新构造的），
+    哈希必须一致；否则 dict/set 行为会损坏。
+    """
+    cls_name, member, name, _ = enum_case
+    # 用 __reduce__ + 构造器复刻一份"同变体的新对象"
+    twin = Operate.from_str(name) if cls_name == "Operate" else type(member)(name)
+    assert member == twin
+    assert hash(member) == hash(twin), f"{cls_name}.{name} 的 hash 在重构后变了，违反 Python 数据模型"
+
+
+def test_eq_with_value_string_does_not_require_hash_match():
+    """`__richcmp__` 允许 ``Freq.F30 == 任何 .value == '30分钟' 的对象``，
+    这是历史兼容路径；不在此处强制要求 hash 一致（跨类型比较本来就在
+    Python 数据模型的"未定义"区，dict/set 不会依赖这种情况）。"""
+
+    class FakeValueHolder:
+        value = "30分钟"
+
+    # Yoda 写法是有意的：本测试要验证 Freq 在左侧时走 `__richcmp__` 的
+    # ".value 字符串兼容路径"，反过来写就变成在测 FakeValueHolder 的 __eq__，
+    # 测试意图完全不同。
+    assert Freq.F30 == FakeValueHolder()  # noqa: SIM300 — 见上方注释，刻意保留 Yoda 形式
+
+
+def test_enum_pickle_roundtrip_preserves_name_and_hash(enum_case):
+    """pickle 往返不应改变 ``name`` / ``value`` / ``hash``。
+
+    安全性说明：此处 ``pickle.loads`` 反序列化的是本测试上一行 ``pickle.dumps``
+    自己生成的字节串，属于受控的同进程往返测试，**不是**加载外部不可信
+    数据，因此不存在 pickle RCE 风险。
+    """
+    _, member, expected_name, expected_value = enum_case
+    restored = pickle.loads(pickle.dumps(member))  # noqa: S301 — 见 docstring 中的安全性说明
+    assert type(restored) is type(member)
+    assert restored.name == expected_name
+    assert restored.value == expected_value
+    assert restored == member
+    assert hash(restored) == hash(member)
+
+
+def test_freq_repr_unchanged():
+    """``__repr__`` 行为保持不变（Freq.F30 形式）。"""
+    assert repr(Freq.F30) == "Freq.F30"
+    assert repr(Freq.D) == "Freq.D"
+
+
+def test_mark_direction_repr_unchanged():
+    assert repr(Mark.G) == "Mark.G"
+    assert repr(Direction.Up) == "Direction.Up"
+
+
+def test_operate_repr_is_consistent_with_other_enums():
+    """`Operate` 的 ``__repr__`` 必须返回 ``Operate.<Variant>`` 形式，
+    与 Freq / Mark / Direction 一致，不再泄漏内部 Rust 结构名
+    （历史上曾返回 ``"PyOperate::HL"``）。"""
+    assert repr(Operate.HL) == "Operate.HL"
+    assert repr(Operate.SE) == "Operate.SE"
+    assert repr(Operate.HO) == "Operate.HO"


### PR DESCRIPTION
## Summary

- `Freq` / `Mark` / `Direction` / `Operate` 之前在 Python 端只有 `.value`（中文显示串）和 `__repr__`，**缺 `.name` 且不可哈希**，没法做 `dict` / `set` key，也跟标准库 `enum.Enum.name` 习惯不对齐。
- 根因：PyO3 不会自动把 Rust `Hash` trait 导出为 Python `__hash__`；只要 `pyclass` 定义了 `__richcmp__`（即 `__eq__`）却没显式给 `__hash__`，PyO3 会把 `__hash__` 显式设为 `None`，强制实例不可哈希。
- 按宪法第一条（Rust ↔ Python 行为一致），修复**全部在 Rust 侧**、Python 端零改动。

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/czsc-core/src/objects/freq.rs` | 加 `name` getter + `__hash__` |
| `crates/czsc-core/src/objects/mark.rs` | derive 加 `Eq, Hash`；新增 `__new__` / `__reduce__` / `__deepcopy__` / `name` / `__hash__`（顺手补齐 pre-existing 的"不能 pickle / 不能从字符串构造"gap，与 Freq / Direction 对齐） |
| `crates/czsc-core/src/objects/direction.rs` | derive 加 `Eq, Hash`；新增 `name` / `__hash__` |
| `crates/czsc-core/src/objects/operate.rs` | derive 加 `Eq`；PyOperate 加 `name` getter（`__hash__` 早就有） |
| `czsc/_native/__init__.pyi` | `pyo3-stub-gen` 自动重生成，+55 行 |
| `tests/unit/test_native_enum_ergonomics.py`（新） | 64 个参数化用例覆盖 4 个 enum 的 `.name` / hashable / dict-key / set-dedup / pickle 往返 / hash-eq 不变量，作为 ratchet 防止未来回退 |

## Test plan

- [x] `uv run --no-sync pytest tests/unit tests/compat -q` → **288 passed**
- [x] `uv run --no-sync pytest tests/unit/test_native_enum_ergonomics.py -v` → **64/64 passed**
- [x] `cargo fmt --all -- --check` 干净
- [x] `uv run --no-sync ruff check czsc tests` 干净
- [x] `cargo test -p czsc-core --lib objects::` 本地跑过（不带 python feature，绕开 pyo3-stub-gen 0.22 上游 build 问题）→ 22/22 passed
- [x] 烟测：`hash(Freq.F30)` 可用、`{Freq.F30, Freq.D, Mark.G, Direction.Up, Operate.HL}` 可作为集合元素、`Freq.F30.name == 'F30'`

## 风险与边界

- **向后兼容**：纯新增 API，不动 `.value` / `__repr__` / `__str__` / `__richcmp__` 的现有语义。
- **哈希不变量**：`__hash__` 用 derived `Hash`，仅基于 Rust enum variant 身份；`__richcmp__` 仍允许"`Freq.F30 == 任何 .value == '30分钟' 的对象`"这种跨类型 .value 字符串兼容比较——该行为本就处于 Python 数据模型的"未定义"区，dict / set 不应依赖；新测试 `test_eq_with_value_string_does_not_require_hash_match` 明确把它框成"刻意保留的旧 API"。
- **CI**：`cargo test --features python` 因 `pyo3-stub-gen 0.22.2` 与 `pyo3 0.28.3` 上游兼容性问题（`PyEncodingWarning` 找不到）跑不起来——与本 PR 无关，可另开 issue 跟踪升级。