### PR TITLE
feat(cli): 新增 typer CLI 模块，暴露 czsc 核心能力供 LLM/人类调用

### DIFF
--- a/czsc/cli/__init__.py
+++ b/czsc/cli/__init__.py
@@ -1,0 +1,29 @@
+"""CZSC 命令行工具入口。
+
+通过 ``czsc <子命令>`` 调用；所有命令支持 ``--json`` 输出（LLM 友好）。
+"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import analyze, backtest, bench, data, plot, research, schema, signals
+
+app = typer.Typer(
+    help="CZSC 缠论技术分析命令行工具",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+app.add_typer(signals.app, name="signals", help="信号目录与文档")
+app.add_typer(research.app, name="research", help="策略研究 / 回放 / 配置解析")
+app.add_typer(data.app, name="data", help="造数与质量校验")
+app.add_typer(plot.app, name="plot", help="缠论 / 信号 HTML 可视化")
+app.command("analyze", help="对一段 K 线跑缠论，输出分型 + 笔")(analyze.analyze)
+app.command("backtest", help="传入 Position 对象 + 数据源，产出回测结果")(backtest.backtest)
+app.command("bench", help="CZSC 吞吐量基准")(bench.bench)
+app.command("schema", help="吐出全部命令/参数 schema 供 LLM 自发现")(schema.schema)
+
+
+if __name__ == "__main__":
+    app()

--- a/czsc/cli/_io.py
+++ b/czsc/cli/_io.py
@@ -1,0 +1,127 @@
+"""CLI 共享层：输入加载、输出渲染、错误边界、连接器分发。"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import typer
+
+from czsc import Freq, format_standard_kline
+
+REQUIRED_OHLCV = ["dt", "symbol", "open", "close", "high", "low", "vol", "amount"]
+
+# czsc._native.Freq 是 PyO3 枚举：不可下标、不可迭代，只能 getattr 取成员。
+_FREQ_NAMES = [
+    "Tick",
+    "F1",
+    "F2",
+    "F3",
+    "F4",
+    "F5",
+    "F6",
+    "F10",
+    "F12",
+    "F15",
+    "F20",
+    "F30",
+    "F60",
+    "F120",
+    "F240",
+    "F360",
+    "D",
+    "W",
+    "M",
+    "S",
+    "Y",
+]
+_FREQ_CN = {m.value for m in (getattr(Freq, n, None) for n in _FREQ_NAMES) if m is not None}
+
+
+def freq_to_cn(freq: str) -> str:
+    """把 Freq 枚举名（F30/D…）或中文（30分钟）统一成中文频率字符串。"""
+    member = getattr(Freq, freq, None)
+    if member is not None and hasattr(member, "value"):
+        return member.value  # "F30" -> "30分钟"
+    if freq in _FREQ_CN:
+        return freq
+    raise ValueError(f"无法识别的频率: {freq}；可用枚举名如 F30/D 或中文如 30分钟")
+
+
+def load_bars_df(path: str) -> pd.DataFrame:
+    """从 CSV/parquet/feather 或 stdin(-) 读标准 OHLCV DataFrame 并校验。"""
+    # symbol 必须按字符串读，否则像 "000001" 这类代码会被解析成整数丢掉前导零
+    if path == "-":
+        df = pd.read_csv(sys.stdin, dtype={"symbol": str})
+    else:
+        p = Path(path)
+        suffix = p.suffix.lower()
+        if suffix == ".csv":
+            df = pd.read_csv(p, dtype={"symbol": str})
+        elif suffix in (".parquet", ".pq"):
+            df = pd.read_parquet(p)
+        elif suffix in (".feather", ".ipc"):
+            df = pd.read_feather(p)
+        else:
+            raise ValueError(f"不支持的行情文件类型: {suffix}（支持 .csv/.parquet/.feather）")
+    missing = [c for c in REQUIRED_OHLCV if c not in df.columns]
+    if missing:
+        raise ValueError(f"行情数据缺少必需列: {missing}；需要 {REQUIRED_OHLCV}")
+    df["dt"] = pd.to_datetime(df["dt"])
+    if "symbol" in df.columns:
+        df["symbol"] = df["symbol"].astype(str)
+    return df
+
+
+def emit(data: Any, *, json_out: bool, human: Callable[[Any], None]) -> None:
+    """统一输出：json_out 时 stdout 纯 JSON；否则调 human 渲染。"""
+    if json_out:
+        typer.echo(json.dumps(data, ensure_ascii=False, default=str))
+    else:
+        human(data)
+
+
+def fail(message: str, *, json_out: bool, err_type: str = "error", code: int = 1) -> None:
+    """统一错误：json_out → stderr JSON；否则红字；退出非零。"""
+    if json_out:
+        typer.echo(json.dumps({"error": {"type": err_type, "message": message}}, ensure_ascii=False), err=True)
+    else:
+        typer.secho(f"错误: {message}", fg=typer.colors.RED, err=True)
+    raise typer.Exit(code)
+
+
+@contextmanager
+def error_boundary(json_out: bool):
+    """命令体统一异常边界：未捕获异常 → fail()。"""
+    try:
+        yield
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001
+        fail(str(e), json_out=json_out, err_type=type(e).__name__)
+
+
+def resolve_bars_for_symbol(symbol: str, *, source: str, freq: str, sdt: str, edt: str):
+    """按 source 懒加载连接器，返回该 symbol 的 list[RawBar]。"""
+    cn = freq_to_cn(freq)
+    if source == "local":
+        from czsc.connectors import local_data
+
+        return local_data.get_raw_bars(symbol, cn, sdt, edt)
+    if source == "tushare":
+        from czsc.connectors import ts_connector
+
+        return ts_connector.get_raw_bars(symbol, cn, sdt, edt)
+    if source == "ccxt":
+        from czsc.connectors import ccxt_connector
+
+        df = ccxt_connector.get_raw_bars(symbol=symbol, period=cn, sdt=sdt, edt=edt)
+        if "symbol" not in df.columns:
+            df = df.assign(symbol=symbol)
+        return format_standard_kline(df, cn)
+    raise ValueError(f"未知数据源: {source}（支持 local/tushare/ccxt）")

--- a/czsc/cli/_io.py
+++ b/czsc/cli/_io.py
@@ -42,6 +42,19 @@ _FREQ_NAMES = [
 ]
 _FREQ_CN = {m.value for m in (getattr(Freq, n, None) for n in _FREQ_NAMES) if m is not None}
 
+# ccxt 连接器只认 ccxt 周期串（1m/1h/1d…），需把中文频率映射过去
+_CN_TO_CCXT = {
+    "1分钟": "1m",
+    "5分钟": "5m",
+    "15分钟": "15m",
+    "30分钟": "30m",
+    "60分钟": "1h",
+    "120分钟": "2h",
+    "240分钟": "4h",
+    "360分钟": "6h",
+    "日线": "1d",
+}
+
 
 def freq_to_cn(freq: str) -> str:
     """把 Freq 枚举名（F30/D…）或中文（30分钟）统一成中文频率字符串。"""
@@ -120,7 +133,10 @@ def resolve_bars_for_symbol(symbol: str, *, source: str, freq: str, sdt: str, ed
     if source == "ccxt":
         from czsc.connectors import ccxt_connector
 
-        df = ccxt_connector.get_raw_bars(symbol=symbol, period=cn, sdt=sdt, edt=edt)
+        ccxt_period = _CN_TO_CCXT.get(cn)
+        if ccxt_period is None:
+            raise ValueError(f"ccxt 数据源不支持频率 {cn}；支持 {sorted(_CN_TO_CCXT)}")
+        df = ccxt_connector.get_raw_bars(symbol=symbol, period=ccxt_period, sdt=sdt, edt=edt)
         if "symbol" not in df.columns:
             df = df.assign(symbol=symbol)
         return format_standard_kline(df, cn)

--- a/czsc/cli/_io.py
+++ b/czsc/cli/_io.py
@@ -15,32 +15,7 @@ import typer
 from czsc import Freq, format_standard_kline
 
 REQUIRED_OHLCV = ["dt", "symbol", "open", "close", "high", "low", "vol", "amount"]
-
-# czsc._native.Freq 是 PyO3 枚举：不可下标、不可迭代，只能 getattr 取成员。
-_FREQ_NAMES = [
-    "Tick",
-    "F1",
-    "F2",
-    "F3",
-    "F4",
-    "F5",
-    "F6",
-    "F10",
-    "F12",
-    "F15",
-    "F20",
-    "F30",
-    "F60",
-    "F120",
-    "F240",
-    "F360",
-    "D",
-    "W",
-    "M",
-    "S",
-    "Y",
-]
-_FREQ_CN = {m.value for m in (getattr(Freq, n, None) for n in _FREQ_NAMES) if m is not None}
+_NUMERIC_OHLCV = ["open", "close", "high", "low", "vol", "amount"]
 
 # ccxt 连接器只认 ccxt 周期串（1m/1h/1d…），需把中文频率映射过去
 _CN_TO_CCXT = {
@@ -57,13 +32,15 @@ _CN_TO_CCXT = {
 
 
 def freq_to_cn(freq: str) -> str:
-    """把 Freq 枚举名（F30/D…）或中文（30分钟）统一成中文频率字符串。"""
-    member = getattr(Freq, freq, None)
-    if member is not None and hasattr(member, "value"):
-        return member.value  # "F30" -> "30分钟"
-    if freq in _FREQ_CN:
-        return freq
-    raise ValueError(f"无法识别的频率: {freq}；可用枚举名如 F30/D 或中文如 30分钟")
+    """把 Freq 枚举名（F30/D…）或中文（30分钟）统一成中文频率字符串。
+
+    直接走 ``czsc.Freq`` 构造器：它同时接受枚举名与中文值，非法值抛 ValueError，
+    与 Rust 端的频率定义保持单一来源，避免在 Python 侧手抄枚举清单造成漂移。
+    """
+    try:
+        return Freq(freq).value
+    except (ValueError, KeyError) as e:
+        raise ValueError(f"无法识别的频率: {freq}；可用枚举名如 F30/D 或中文如 30分钟") from e
 
 
 def load_bars_df(path: str) -> pd.DataFrame:
@@ -86,8 +63,10 @@ def load_bars_df(path: str) -> pd.DataFrame:
     if missing:
         raise ValueError(f"行情数据缺少必需列: {missing}；需要 {REQUIRED_OHLCV}")
     df["dt"] = pd.to_datetime(df["dt"])
-    if "symbol" in df.columns:
-        df["symbol"] = df["symbol"].astype(str)
+    # symbol 统一为字符串（避免 000001 被当整数）；OHLCV 数值列统一为 float —— 否则
+    # run_research / run_replay 透传给 Rust(Polars) 时 int64 的 vol 会被拒（要求 Float64）。
+    df["symbol"] = df["symbol"].astype(str)
+    df[_NUMERIC_OHLCV] = df[_NUMERIC_OHLCV].astype(float)
     return df
 
 

--- a/czsc/cli/analyze.py
+++ b/czsc/cli/analyze.py
@@ -1,0 +1,62 @@
+"""analyze 命令：对一段 K 线跑缠论，输出分型 + 笔。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+
+def _fx_to_dict(fx) -> dict:
+    return {
+        "dt": fx.dt,
+        "mark": str(fx.mark),
+        "fx": fx.fx,
+        "high": fx.high,
+        "low": fx.low,
+        "power_str": getattr(fx, "power_str", None),
+    }
+
+
+def _bi_to_dict(bi) -> dict:
+    return {
+        "sdt": bi.sdt,
+        "edt": bi.edt,
+        "direction": str(bi.direction),
+        "high": bi.high,
+        "low": bi.low,
+        "length": bi.length,
+        "power": bi.power,
+    }
+
+
+def analyze(
+    input: str = typer.Argument(..., help="标准行情文件（CSV/parquet/feather）或 - 读 stdin"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率（中文或枚举名 F30）"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """缠论分型 + 笔识别（czsc.CZSC）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+
+        df = _io.load_bars_df(input)
+        cn = _io.freq_to_cn(freq)
+        bars = format_standard_kline(df, cn)
+        c = CZSC(bars)
+        out = {
+            "symbol": c.symbol,
+            "freq": cn,
+            "bars": len(c.bars_raw),
+            "fx_list": [_fx_to_dict(fx) for fx in c.fx_list],
+            "bi_list": [_bi_to_dict(bi) for bi in c.bi_list],
+        }
+
+        def human(d):
+            typer.echo(f"{d['symbol']} {d['freq']}  bars={d['bars']}  分型={len(d['fx_list'])}  笔={len(d['bi_list'])}")
+            for bi in d["bi_list"][-5:]:
+                typer.echo(
+                    f"  笔 {bi['direction']} {bi['sdt']}~{bi['edt']} "
+                    f"[{bi['low']:.2f},{bi['high']:.2f}] len={bi['length']}"
+                )
+
+        _io.emit(out, json_out=json_out, human=human)

--- a/czsc/cli/backtest.py
+++ b/czsc/cli/backtest.py
@@ -1,0 +1,96 @@
+"""backtest 命令：传入 Position 对象 + 数据源，产出回测结果。"""
+
+from __future__ import annotations
+
+import json as _json
+
+import pandas as pd
+import typer
+
+from czsc import CzscStrategyBase, Position, WeightBacktest, format_standard_kline
+from czsc.cli import _io
+
+
+class _PositionsStrategy(CzscStrategyBase):
+    """把外部传入的 positions 注入抽象基类（基类 positions 为抽象属性）。"""
+
+    def __init__(self, position_list, **kwargs):
+        self._position_list = position_list
+        super().__init__(**kwargs)
+
+    @property
+    def positions(self):
+        return self._position_list
+
+
+def _holds_to_weight(holds: pd.DataFrame) -> pd.DataFrame:
+    """holds_df -> 权重表 {dt,symbol,weight,price}；多 position 按 (dt,symbol) 等权聚合。"""
+    return holds.groupby(["dt", "symbol"], as_index=False).agg(weight=("pos", "mean"), price=("price", "first"))
+
+
+def _backtest_symbol(positions, bars, symbol: str) -> pd.DataFrame:
+    strat = _PositionsStrategy(positions, symbol=symbol)
+    res = strat.backtest(bars)
+    return _holds_to_weight(res.holds_df())
+
+
+def backtest(
+    positions: list[str] = typer.Argument(..., help="一个或多个 Position JSON 文件"),
+    symbol: list[str] = typer.Option(None, "--symbol", help="标的（可重复或逗号分隔，支持多 symbol）"),
+    source: str = typer.Option("local", "--source", help="数据源 local/tushare/ccxt"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    sdt: str = typer.Option("20200101", "--sdt", help="起始日期"),
+    edt: str = typer.Option("20240101", "--edt", help="结束日期"),
+    bars_file: str = typer.Option(None, "--bars", help="标准行情文件（可含多 symbol）；与 --symbol 二选一"),
+    html: str = typer.Option(None, "--html", help="生成 wbt HTML 回测报告路径"),
+    output: str = typer.Option(None, "-o", "--output", help="结果 JSON 落盘路径"),
+    fee_rate: float = typer.Option(2e-4, "--fee-rate", help="手续费率"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """positions + 数据源 → 逐 symbol 回测 + 组合聚合（czsc 回测 + WeightBacktest）。"""
+    with _io.error_boundary(json_out):
+        pos_objs = []
+        for p in positions:
+            with open(p, encoding="utf-8") as fh:
+                pos_objs.append(Position.from_json(fh.read()))
+
+        weight_frames: dict[str, pd.DataFrame] = {}
+        if bars_file:
+            df = _io.load_bars_df(bars_file)
+            for sym, g in df.groupby("symbol"):
+                bars = format_standard_kline(g, _io.freq_to_cn(freq))
+                weight_frames[str(sym)] = _backtest_symbol(pos_objs, bars, str(sym))
+        else:
+            syms: list[str] = []
+            for s in symbol or []:
+                syms.extend(x for x in s.split(",") if x)
+            if not syms:
+                raise ValueError("必须提供 --symbol（可多个）或 --bars 行情文件之一")
+            for sym in syms:
+                bars = _io.resolve_bars_for_symbol(sym, source=source, freq=freq, sdt=sdt, edt=edt)
+                weight_frames[sym] = _backtest_symbol(pos_objs, bars, sym)
+
+        per_symbol = {sym: WeightBacktest(w, fee_rate=fee_rate).stats for sym, w in weight_frames.items()}
+        portfolio_w = pd.concat(weight_frames.values(), ignore_index=True)
+        portfolio = WeightBacktest(portfolio_w, fee_rate=fee_rate).stats
+
+        if html:
+            from wbt import generate_backtest_report
+
+            generate_backtest_report(portfolio_w, output_path=html, title="CZSC 回测报告")
+
+        result = {"symbols": per_symbol, "portfolio": portfolio, "html": html}
+        if output:
+            with open(output, "w", encoding="utf-8") as fh:
+                fh.write(_json.dumps(result, ensure_ascii=False, default=str))
+
+        def human(d):
+            typer.echo("== 组合绩效 ==")
+            for k in ["年化收益", "夏普比率", "最大回撤", "日胜率"]:
+                typer.echo(f"  {k}: {d['portfolio'].get(k)}")
+            for sym, st in d["symbols"].items():
+                typer.echo(f"  [{sym}] 年化={st.get('年化收益')} 夏普={st.get('夏普比率')}")
+            if d["html"]:
+                typer.echo(f"HTML 报告: {d['html']}")
+
+        _io.emit(result, json_out=json_out, human=human)

--- a/czsc/cli/backtest.py
+++ b/czsc/cli/backtest.py
@@ -31,10 +31,11 @@ def _holds_to_weight(holds: pd.DataFrame, symbol: str) -> pd.DataFrame:
     """
     cols = ["dt", "symbol", "weight", "price"]
     if holds is None or holds.empty:
-        return pd.DataFrame(columns=cols)
-    w = holds.groupby(["dt"], as_index=False).agg(weight=("pos", "mean"), price=("price", "first"))
-    w["symbol"] = symbol
-    return w[cols]
+        return pd.DataFrame(columns=pd.Index(cols))
+    # groupby().agg() 在 pandas stub 下被推断为 DataFrame|Series union，这里实为 DataFrame
+    w = holds.groupby("dt", as_index=False).agg(weight=("pos", "mean"), price=("price", "first"))
+    w["symbol"] = symbol  # type: ignore[index]
+    return w[cols]  # type: ignore[return-value]
 
 
 def _backtest_symbol(positions, bars, symbol: str) -> pd.DataFrame:
@@ -91,7 +92,7 @@ def backtest(
             portfolio_w = pd.concat(nonempty, ignore_index=True)
             portfolio = WeightBacktest(portfolio_w, fee_rate=fee_rate).stats
         else:
-            portfolio_w = pd.DataFrame(columns=["dt", "symbol", "weight", "price"])
+            portfolio_w = pd.DataFrame(columns=pd.Index(["dt", "symbol", "weight", "price"]))
             portfolio = {"warning": "全部 symbol 无成交"}
 
         html_written = None

--- a/czsc/cli/backtest.py
+++ b/czsc/cli/backtest.py
@@ -23,15 +23,26 @@ class _PositionsStrategy(CzscStrategyBase):
         return self._position_list
 
 
-def _holds_to_weight(holds: pd.DataFrame) -> pd.DataFrame:
-    """holds_df -> 权重表 {dt,symbol,weight,price}；多 position 按 (dt,symbol) 等权聚合。"""
-    return holds.groupby(["dt", "symbol"], as_index=False).agg(weight=("pos", "mean"), price=("price", "first"))
+def _holds_to_weight(holds: pd.DataFrame, symbol: str) -> pd.DataFrame:
+    """holds_df -> 权重表 {dt,symbol,weight,price}；多 position 按 dt 等权聚合。
+
+    holds 为空（该 symbol 零成交）时返回空表；symbol 列强制用回测标的，避免
+    被 position 自带的 symbol 串味（holds_df 的 symbol 取自 position.symbol）。
+    """
+    cols = ["dt", "symbol", "weight", "price"]
+    if holds is None or holds.empty:
+        return pd.DataFrame(columns=cols)
+    w = holds.groupby(["dt"], as_index=False).agg(weight=("pos", "mean"), price=("price", "first"))
+    w["symbol"] = symbol
+    return w[cols]
 
 
 def _backtest_symbol(positions, bars, symbol: str) -> pd.DataFrame:
     strat = _PositionsStrategy(positions, symbol=symbol)
+    if not strat.signals_config:
+        raise ValueError("position 未解析出任何有效信号（请检查 Position JSON 里的信号名是否正确）")
     res = strat.backtest(bars)
-    return _holds_to_weight(res.holds_df())
+    return _holds_to_weight(res.holds_df(), symbol)
 
 
 def backtest(
@@ -70,16 +81,27 @@ def backtest(
                 bars = _io.resolve_bars_for_symbol(sym, source=source, freq=freq, sdt=sdt, edt=edt)
                 weight_frames[sym] = _backtest_symbol(pos_objs, bars, sym)
 
-        per_symbol = {sym: WeightBacktest(w, fee_rate=fee_rate).stats for sym, w in weight_frames.items()}
-        portfolio_w = pd.concat(weight_frames.values(), ignore_index=True)
-        portfolio = WeightBacktest(portfolio_w, fee_rate=fee_rate).stats
+        # 零成交的 symbol 不进 WeightBacktest（空权重表会抛底层转换错），单独标注
+        per_symbol = {}
+        for sym, w in weight_frames.items():
+            per_symbol[sym] = {"warning": "无成交"} if w.empty else WeightBacktest(w, fee_rate=fee_rate).stats
 
-        if html:
+        nonempty = [w for w in weight_frames.values() if not w.empty]
+        if nonempty:
+            portfolio_w = pd.concat(nonempty, ignore_index=True)
+            portfolio = WeightBacktest(portfolio_w, fee_rate=fee_rate).stats
+        else:
+            portfolio_w = pd.DataFrame(columns=["dt", "symbol", "weight", "price"])
+            portfolio = {"warning": "全部 symbol 无成交"}
+
+        html_written = None
+        if html and not portfolio_w.empty:
             from wbt import generate_backtest_report
 
             generate_backtest_report(portfolio_w, output_path=html, title="CZSC 回测报告")
+            html_written = html
 
-        result = {"symbols": per_symbol, "portfolio": portfolio, "html": html}
+        result = {"symbols": per_symbol, "portfolio": portfolio, "html": html_written}
         if output:
             with open(output, "w", encoding="utf-8") as fh:
                 fh.write(_json.dumps(result, ensure_ascii=False, default=str))

--- a/czsc/cli/bench.py
+++ b/czsc/cli/bench.py
@@ -1,0 +1,54 @@
+"""bench 命令：CZSC 吞吐量基准（沿用 examples/17 逻辑）。"""
+
+from __future__ import annotations
+
+import time
+
+import typer
+
+from czsc.cli import _io
+
+
+def bench(
+    years: int = typer.Option(20, "--years", help="模拟数据年数"),
+    freq: str = typer.Option("5分钟", "--freq", help="频率"),
+    symbol: str = typer.Option("000001", "--symbol", help="标的"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """本地复现 CZSC 单周期吞吐量（bars/s）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+        from czsc.mock import generate_symbol_kines
+
+        end_year = 2024
+        sdt = f"{end_year - years:04d}0101"
+        edt = f"{end_year:04d}0101"
+        cn = _io.freq_to_cn(freq)
+        df = generate_symbol_kines(symbol, cn, sdt, edt)
+        bars = format_standard_kline(df, cn)
+        n = len(bars)
+
+        t0 = time.perf_counter()
+        CZSC(bars)
+        construct_sec = time.perf_counter() - t0
+
+        t1 = time.perf_counter()
+        c2 = CZSC(bars[:1])
+        for bar in bars[1:]:
+            c2.update(bar)
+        update_sec = time.perf_counter() - t1
+
+        out = {
+            "symbol": symbol,
+            "freq": cn,
+            "bars": n,
+            "czsc_construct": {"sec": round(construct_sec, 4), "bars_per_sec": round(n / construct_sec)},
+            "czsc_update": {"sec": round(update_sec, 4), "bars_per_sec": round(n / update_sec)},
+        }
+
+        def human(d):
+            typer.echo(f"{d['symbol']} {d['freq']}  bars={d['bars']}")
+            typer.echo(f"  构造:    {d['czsc_construct']['bars_per_sec']:>12,} bars/s")
+            typer.echo(f"  增量推进: {d['czsc_update']['bars_per_sec']:>12,} bars/s")
+
+        _io.emit(out, json_out=json_out, human=human)

--- a/czsc/cli/data.py
+++ b/czsc/cli/data.py
@@ -46,16 +46,32 @@ def quality(
 ) -> None:
     """K 线质量校验（czsc.check_kline_quality）。"""
     with _io.error_boundary(json_out):
+        import contextlib
+        import io
+
         import czsc
 
         df = _io.load_bars_df(input)
-        report = czsc.check_kline_quality(df)
-        slim = {sym: {k: v.get("description") for k, v in checks.items()} for sym, checks in report.items()}
+        # check_kline_quality 在发现问题时会把问题行 print 到 stdout，会污染 --json
+        # 的纯 JSON 契约 —— 重定向吃掉这个副作用，问题行数从返回结构里另行给出。
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            report = czsc.check_kline_quality(df)
+        slim = {}
+        for sym, checks in report.items():
+            slim[sym] = {}
+            for k, v in checks.items():
+                rows = v.get("rows")
+                slim[sym][k] = {
+                    "description": v.get("description"),
+                    "n_bad_rows": int(len(rows)) if rows is not None else 0,
+                }
 
         def human(d):
             for sym, checks in d.items():
                 typer.echo(f"[{sym}]")
-                for k, desc in checks.items():
-                    typer.echo(f"  {k}: {desc}")
+                for k, info in checks.items():
+                    flag = "" if info["n_bad_rows"] == 0 else f"  ⚠️ {info['n_bad_rows']} 行异常"
+                    typer.echo(f"  {k}: {info['description']}{flag}")
 
         _io.emit(slim, json_out=json_out, human=human)

--- a/czsc/cli/data.py
+++ b/czsc/cli/data.py
@@ -1,0 +1,59 @@
+"""data 子命令组：造数与质量校验。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("mock")
+def mock(
+    symbol: str = typer.Option("000001", help="标的代码"),
+    freq: str = typer.Option("30分钟", help="频率（中文或枚举名 F30）"),
+    sdt: str = typer.Option("20200101", help="起始日期"),
+    edt: str = typer.Option("20210101", help="结束日期"),
+    seed: int = typer.Option(42, help="随机种子（可复现）"),
+    output: str = typer.Option(None, "-o", "--output", help="输出 CSV 路径；缺省打印到 stdout"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """生成标准 OHLCV K 线（czsc.mock.generate_symbol_kines）。"""
+    with _io.error_boundary(json_out):
+        from czsc.mock import generate_symbol_kines
+
+        df = generate_symbol_kines(symbol, _io.freq_to_cn(freq), sdt, edt, seed=seed)
+        if output:
+            df.to_csv(output, index=False)
+            _io.emit(
+                {"output": output, "rows": len(df)},
+                json_out=json_out,
+                human=lambda d: typer.echo(f"已写入 {d['output']}（{d['rows']} 行）"),
+            )
+        elif json_out:
+            typer.echo(df.to_json(orient="records", force_ascii=False, date_format="iso"))
+        else:
+            typer.echo(df.to_string(index=False))
+
+
+@app.command("quality")
+def quality(
+    input: str = typer.Argument(..., help="标准行情文件（CSV/parquet/feather）或 - 读 stdin"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """K 线质量校验（czsc.check_kline_quality）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(input)
+        report = czsc.check_kline_quality(df)
+        slim = {sym: {k: v.get("description") for k, v in checks.items()} for sym, checks in report.items()}
+
+        def human(d):
+            for sym, checks in d.items():
+                typer.echo(f"[{sym}]")
+                for k, desc in checks.items():
+                    typer.echo(f"  {k}: {desc}")
+
+        _io.emit(slim, json_out=json_out, human=human)

--- a/czsc/cli/data.py
+++ b/czsc/cli/data.py
@@ -31,10 +31,12 @@ def mock(
                 json_out=json_out,
                 human=lambda d: typer.echo(f"已写入 {d['output']}（{d['rows']} 行）"),
             )
-        elif json_out:
-            typer.echo(df.to_json(orient="records", force_ascii=False, date_format="iso"))
         else:
-            typer.echo(df.to_string(index=False))
+            _io.emit(
+                df.to_dict("records"),
+                json_out=json_out,
+                human=lambda d: typer.echo(df.to_string(index=False)),
+            )
 
 
 @app.command("quality")

--- a/czsc/cli/plot.py
+++ b/czsc/cli/plot.py
@@ -1,0 +1,62 @@
+"""plot 子命令组：缠论 / 信号 HTML 可视化。"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("czsc")
+def czsc_cmd(
+    input: str = typer.Argument(..., help="标准行情文件"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    output: str = typer.Option("czsc.html", "-o", "--output", help="HTML 输出路径"),
+    theme: str = typer.Option("light", "--theme", help="light/dark"),
+    tail_bars: int = typer.Option(None, "--tail-bars", help="只画最后 N 根"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """单周期缠论结构 HTML（plot_czsc）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+        from czsc.utils.plotting.lightweight import plot_czsc
+
+        df = _io.load_bars_df(input)
+        c = CZSC(format_standard_kline(df, _io.freq_to_cn(freq)))
+        plot_czsc(c, output="html", path=output, theme=theme, tail_bars=tail_bars)
+        _io.emit(
+            {"output": output},
+            json_out=json_out,
+            human=lambda d: typer.echo(f"已写入 {d['output']}"),
+        )
+
+
+@app.command("signals")
+def signals_cmd(
+    input: str = typer.Argument(..., help="标准行情文件"),
+    signals_config: str = typer.Option(..., "--signals-config", help="signals_config JSON 文件"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    output: str = typer.Option("signals.html", "-o", "--output", help="HTML 输出路径"),
+    sdt: str = typer.Option("20170101", "--sdt", help="信号起始日期"),
+    tail_bars: int = typer.Option(None, "--tail-bars", help="只画最后 N 根"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """信号叠加到 K 线主图 HTML（plot_czsc_signals）。"""
+    with _io.error_boundary(json_out):
+        from czsc import format_standard_kline
+        from czsc.utils.plotting.lightweight import plot_czsc_signals
+
+        df = _io.load_bars_df(input)
+        bars = format_standard_kline(df, _io.freq_to_cn(freq))
+        with open(signals_config, encoding="utf-8") as fh:
+            cfg = json.loads(fh.read())
+        plot_czsc_signals(bars, signals_config=cfg, output="html", path=output, sdt=sdt, tail_bars=tail_bars)
+        _io.emit(
+            {"output": output},
+            json_out=json_out,
+            human=lambda d: typer.echo(f"已写入 {d['output']}"),
+        )

--- a/czsc/cli/plot.py
+++ b/czsc/cli/plot.py
@@ -27,7 +27,7 @@ def czsc_cmd(
 
         df = _io.load_bars_df(input)
         c = CZSC(format_standard_kline(df, _io.freq_to_cn(freq)))
-        plot_czsc(c, output="html", path=output, theme=theme, tail_bars=tail_bars)
+        plot_czsc(c, output="html", path=output, theme=theme, tail_bars=tail_bars)  # type: ignore[arg-type]  # theme 为用户字符串，由 plot_czsc 内部校验
         _io.emit(
             {"output": output},
             json_out=json_out,

--- a/czsc/cli/research.py
+++ b/czsc/cli/research.py
@@ -1,0 +1,75 @@
+"""research 子命令组：研究 / 回放 / 配置解析。"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("config")
+def config(
+    signals: list[str] = typer.Argument(..., help="一个或多个信号字符串"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """由信号序列派生 signals_config 与所需频率。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        sc = czsc.get_signals_config(list(signals))
+        freqs = czsc.get_signals_freqs(sc)
+        out = {"signals_config": sc, "freqs": freqs}
+        _io.emit(
+            out,
+            json_out=json_out,
+            human=lambda d: typer.echo(json.dumps(d, ensure_ascii=False, indent=2)),
+        )
+
+
+@app.command("run")
+def run(
+    bars: str = typer.Argument(..., help="标准行情文件"),
+    strategy: str = typer.Argument(..., help="strategy.json（含 symbol/positions/signals_config）"),
+    sdt: str = typer.Option(None, "--sdt", help="起始时间覆盖"),
+    output: str = typer.Option(None, "-o", "--output", help="holds 结果 CSV 落盘路径"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """内存研究（czsc.run_research）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(bars)
+        with open(strategy, encoding="utf-8") as fh:
+            strat = json.loads(fh.read())
+        res = czsc.run_research(df, strat, sdt=sdt)
+        out = {"meta": res.meta}
+        if output:
+            res.holds_df().to_csv(output, index=False)
+            out["holds_csv"] = output
+        _io.emit(out, json_out=json_out, human=lambda d: typer.echo(json.dumps(d, ensure_ascii=False, indent=2)))
+
+
+@app.command("replay")
+def replay(
+    bars: str = typer.Argument(..., help="标准行情文件"),
+    strategy: str = typer.Argument(..., help="strategy.json"),
+    res_path: str = typer.Option(..., "-o", "--output", help="回放结果落盘目录"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """落盘回放（czsc.run_replay）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(bars)
+        with open(strategy, encoding="utf-8") as fh:
+            strat = json.loads(fh.read())
+        res = czsc.run_replay(df, strat, res_path=res_path)
+        _io.emit(
+            {"meta": getattr(res, "meta", {}), "res_path": res_path},
+            json_out=json_out,
+            human=lambda d: typer.echo(f"回放完成 → {d['res_path']}"),
+        )

--- a/czsc/cli/research.py
+++ b/czsc/cli/research.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import typer
 
@@ -46,7 +47,7 @@ def run(
         with open(strategy, encoding="utf-8") as fh:
             strat = json.loads(fh.read())
         res = czsc.run_research(df, strat, sdt=sdt)
-        out = {"meta": res.meta}
+        out: dict[str, Any] = {"meta": res.meta}
         if output:
             res.holds_df().to_csv(output, index=False)
             out["holds_csv"] = output

--- a/czsc/cli/schema.py
+++ b/czsc/cli/schema.py
@@ -1,0 +1,52 @@
+"""schema 元命令：内省 typer app，吐出全部命令/参数 schema 供 LLM 自发现。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+
+def _walk(cmd, prefix):
+    out = []
+    # 命令组（Group）有 commands 属性；叶子命令没有 —— 用 duck-typing 兼容
+    # typer 0.26 自带命令体系，不依赖顶层 click 模块。
+    subcommands = getattr(cmd, "commands", None)
+    if subcommands:
+        for name, sub in subcommands.items():
+            out += _walk(sub, prefix + [name])
+    else:
+        params = []
+        for p in cmd.params:
+            params.append(
+                {
+                    "name": p.name,
+                    "opts": list(getattr(p, "opts", [])),
+                    "type": getattr(p.type, "name", str(p.type)),
+                    "required": bool(p.required),
+                    "is_flag": bool(getattr(p, "is_flag", False)),
+                    "default": p.default if not callable(p.default) else None,
+                    "help": getattr(p, "help", None),
+                }
+            )
+        out.append({"command": " ".join(prefix), "help": (cmd.help or "").strip(), "params": params})
+    return out
+
+
+def schema(
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """导出全部子命令与参数 schema。"""
+    with _io.error_boundary(json_out):
+        from czsc.cli import app as root_app
+
+        cmd = typer.main.get_command(root_app)
+        data = _walk(cmd, ["czsc"])
+
+        def human(rows):
+            for c in rows:
+                typer.echo(f"{c['command']}  —  {c['help']}")
+                for p in c["params"]:
+                    typer.echo(f"    {p['opts'] or [p['name']]}  ({p['type']})  {p['help'] or ''}")
+
+        _io.emit(data, json_out=json_out, human=human)

--- a/czsc/cli/signals.py
+++ b/czsc/cli/signals.py
@@ -1,0 +1,51 @@
+"""signals 子命令组：信号目录与文档。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("list")
+def list_(
+    category: str = typer.Option(None, "--category", help="按 category 过滤"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """列出全部信号函数（czsc._native.list_all_signals）。"""
+    with _io.error_boundary(json_out):
+        import czsc._native as native
+
+        items = native.list_all_signals()
+        if category:
+            items = [it for it in items if it.get("category") == category]
+
+        def human(rows):
+            for it in rows:
+                typer.echo(f"{it['name']:40s} [{it['category']}] {it['param_template']}")
+            typer.echo(f"共 {len(rows)} 个信号")
+
+        _io.emit(items, json_out=json_out, human=human)
+
+
+@app.command("doc")
+def doc(
+    name: str = typer.Argument(..., help="信号函数名"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """单个信号的参数模板与分类（来自 list_all_signals 条目）。"""
+    with _io.error_boundary(json_out):
+        import czsc._native as native
+
+        entry = next((it for it in native.list_all_signals() if it["name"] == name), None)
+        if entry is None:
+            raise ValueError(f"未找到信号: {name}")
+
+        def human(d):
+            typer.echo(f"名称: {d['name']}")
+            typer.echo(f"分类: {d['category']}  命名空间: {d['namespace']}")
+            typer.echo(f"参数模板: {d['param_template']}")
+
+        _io.emit(entry, json_out=json_out, human=human)

--- a/czsc/cli/signals.py
+++ b/czsc/cli/signals.py
@@ -18,7 +18,7 @@ def list_(
     with _io.error_boundary(json_out):
         import czsc._native as native
 
-        items = native.list_all_signals()
+        items = native.list_all_signals()  # type: ignore[attr-defined]  # 运行时存在，stub 未声明
         if category:
             items = [it for it in items if it.get("category") == category]
 
@@ -39,7 +39,7 @@ def doc(
     with _io.error_boundary(json_out):
         import czsc._native as native
 
-        entry = next((it for it in native.list_all_signals() if it["name"] == name), None)
+        entry = next((it for it in native.list_all_signals() if it["name"] == name), None)  # type: ignore[attr-defined]
         if entry is None:
             raise ValueError(f"未找到信号: {name}")
 

--- a/docs/superpowers/plans/2026-06-02-czsc-cli.md
+++ b/docs/superpowers/plans/2026-06-02-czsc-cli.md
@@ -1,0 +1,1479 @@
+# czsc CLI 模块实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 czsc 库新增一个用 typer 写的统一 CLI（入口 `czsc`），把信号目录、缠论分析、策略回测、研究、可视化、性能基准等能力暴露成子命令，人机两用、`--json` LLM 友好、`schema` 自发现。
+
+**Architecture:** 新建 `czsc/cli/` 子包，按命令组拆文件；`_io.py` 收口输入加载/输出渲染/错误边界/连接器分发。每个命令只做「解析参数 → 调 `czsc.*` 公共 API → 交 `_io.py` 渲染」，不写业务/算法逻辑（符合开发宪法）。`pyproject.toml` 注册 `[project.scripts] czsc = "czsc.cli:app"`。
+
+**Tech Stack:** Python 3.10+，typer（+click），pandas，pytest（typer.testing.CliRunner），ruff（line-length 120），uv。
+
+**设计文档：** 飞书 wiki `https://s0cqcxuy3p.feishu.cn/wiki/IoGRwkHxwiiHP8kOWwJc1s85nSb`
+
+---
+
+## 已验证的 API 契约（实测，实现时直接用）
+
+- `czsc._native.list_all_signals() -> list[dict]`（246 项；key：`name` / `param_template` / `category` / `namespace`）
+- `czsc._native.list_signal_names(category=None) -> list[str]`
+- `czsc._native.get_signal_template(name) -> str`、`czsc._native.get_signal_category(name) -> str`
+- `czsc.Freq` 成员 `.value` 为中文（`Freq.F30.value == "30分钟"`，`Freq.D.value == "日线"` …）
+- `czsc.format_standard_kline(df, freq) -> list[RawBar]`；df 必含 `dt,symbol,open,close,high,low,vol,amount`
+- `czsc.mock.generate_symbol_kines(symbol, freq, sdt="20100101", edt="20250101", seed=42) -> df`（列同上）
+- `CZSC(bars)`：`c.fx_list`（FX：`symbol,dt,mark,fx,high,low,power_volume,power_str`）、`c.bi_list`（BI：`symbol,sdt,edt,direction,high,low,length,power,angle`）。**无 `zs_list`**，中枢不在 v1。
+- `czsc.check_kline_quality(df) -> dict[symbol -> dict[check -> {description, rows}]]`
+- `czsc.get_signals_config(list[str]) -> list[dict]`、`czsc.get_signals_freqs(list[dict]) -> list[str]`
+- `czsc.Position`：`to_json()->str`、`from_json(str)->Position`、`save(path)`、`load_from_file(path)->Position`、`dump()->dict`、`unique_signals->list[str]`
+- `czsc.CzscStrategyBase` 是**抽象类**（`positions` 抽象属性）→ CLI 内定义薄子类注入 positions
+- `strat.backtest(bars) -> ResearchResult`；`res.holds_df()` 列 `dt,pos,price,n1b,symbol,pos_name`
+- `czsc.WeightBacktest(w, fee_rate=2e-4).stats -> dict`（25 项：`年化收益/夏普比率/最大回撤/日胜率`…）；`w` 列 `dt,symbol,weight,price`
+- `wbt.generate_backtest_report(df, output_path, title=...) -> str`（df 列 `dt,symbol,weight,price`）
+- `from czsc.utils.plotting.lightweight import plot_czsc, plot_czsc_trader, plot_czsc_signals`；`plot_czsc(c, output='html', path=None)`：`path=None` 返回 HTML 字符串，传 path 写文件返回路径；`plot_czsc_signals(bars, signals_config=[{'name': '...'}], output='html', path=None)`
+- 连接器（懒加载，import 即可能抛错）：`local_data.get_raw_bars(symbol, freq, sdt, edt) -> list[RawBar]`；`ts_connector.get_raw_bars(symbol, freq, sdt, edt) -> list[RawBar]`；`ccxt_connector.get_raw_bars(symbol=, period=, sdt=, edt=) -> DataFrame`（列 `dt,open,high,low,close,vol,amount`，无 symbol）
+
+## 文件结构（先定边界）
+
+| 文件 | 职责 |
+|---|---|
+| `czsc/cli/__init__.py` | 组装 typer `app`，`add_typer` 各子命令组，注册顶层命令 |
+| `czsc/cli/_io.py` | `load_bars_df` / `emit` / `fail` / `error_boundary` / `resolve_bars_for_symbol` / `freq_to_cn` |
+| `czsc/cli/signals.py` | `signals list` / `signals doc` |
+| `czsc/cli/analyze.py` | `analyze` |
+| `czsc/cli/backtest.py` | `backtest`（`_PositionsStrategy` + 多 symbol + 连接器 + WeightBacktest + HTML） |
+| `czsc/cli/research.py` | `research run` / `research replay` / `research config` |
+| `czsc/cli/data.py` | `data mock` / `data quality` |
+| `czsc/cli/plot.py` | `plot czsc` / `plot trader` / `plot signals` |
+| `czsc/cli/bench.py` | `bench` |
+| `czsc/cli/schema.py` | `schema` |
+| `tests/cli/` | 各命令 CliRunner 测试 |
+
+**设计偏差说明（相对飞书 spec）：** `--json` 改为**每条命令的选项**（而非全局 callback），因为 typer 全局 callback 选项必须置于子命令前（`czsc --json signals list`），对 LLM 不友好；改为 `czsc signals list --json` 更顺手。`error_boundary` 统一捕获异常。
+
+---
+
+## Task 0: 依赖与入口骨架
+
+**Files:**
+- Modify: `pyproject.toml`（dependencies 加 `typer`；新增 `[project.scripts]`）
+- Create: `czsc/cli/__init__.py`
+- Test: `tests/cli/__init__.py`、`tests/cli/test_cli_skeleton.py`
+
+- [ ] **Step 1: 安装 typer 依赖**
+
+编辑 `pyproject.toml`，在 `[project].dependencies` 列表末尾（`"tenacity",` 之后）加一行：
+```toml
+    "typer>=0.12.0",
+```
+在 `[project.optional-dependencies]` 之前（约 line 73 附近，dependencies 数组闭合 `]` 之后）新增：
+```toml
+[project.scripts]
+czsc = "czsc.cli:app"
+```
+
+Run: `uv sync --extra dev`
+Expected: 成功安装 typer。
+
+- [ ] **Step 2: 写失败的测试**
+
+Create `tests/cli/__init__.py`（空文件）。
+Create `tests/cli/test_cli_skeleton.py`：
+```python
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_app_help_lists_subcommands():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for name in ["signals", "analyze", "backtest", "research", "data", "plot", "bench", "schema"]:
+        assert name in result.output
+```
+
+- [ ] **Step 3: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_cli_skeleton.py -v`
+Expected: FAIL（`ModuleNotFoundError: czsc.cli` 或子命令未注册）。
+
+- [ ] **Step 4: 写最小实现**
+
+Create `czsc/cli/__init__.py`：
+```python
+"""CZSC 命令行工具入口。
+
+通过 `czsc <子命令>` 调用；所有命令支持 `--json` 输出（LLM 友好）。
+"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import analyze, backtest, bench, data, plot, research, schema, signals
+
+app = typer.Typer(
+    help="CZSC 缠论技术分析命令行工具",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+app.add_typer(signals.app, name="signals", help="信号目录与文档")
+app.add_typer(research.app, name="research", help="策略研究 / 回放 / 配置解析")
+app.add_typer(data.app, name="data", help="造数与质量校验")
+app.add_typer(plot.app, name="plot", help="缠论 / 信号 HTML 可视化")
+app.command("analyze", help="对一段 K 线跑缠论，输出分型 + 笔")(analyze.analyze)
+app.command("backtest", help="传入 Position 对象 + 数据源，产出回测结果")(backtest.backtest)
+app.command("bench", help="CZSC / CzscTrader 吞吐量基准")(bench.bench)
+app.command("schema", help="吐出全部命令/参数 schema 供 LLM 自发现")(schema.schema)
+
+
+if __name__ == "__main__":
+    app()
+```
+
+此 task 依赖后续 task 创建的子模块。为先让骨架测试通过，**先创建各子模块的最小占位**（后续 task 替换为真实实现）。Create 以下占位文件，每个含一个 typer app 或函数：
+
+`czsc/cli/signals.py`、`czsc/cli/research.py`、`czsc/cli/data.py`、`czsc/cli/plot.py`：
+```python
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(no_args_is_help=True)
+```
+
+`czsc/cli/analyze.py`：
+```python
+from __future__ import annotations
+
+
+def analyze() -> None:  # 占位，Task 4 替换
+    ...
+```
+同理 `czsc/cli/backtest.py`（`def backtest(): ...`）、`czsc/cli/bench.py`（`def bench(): ...`）、`czsc/cli/schema.py`（`def schema(): ...`）。
+
+- [ ] **Step 5: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_cli_skeleton.py -v`
+Expected: PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml czsc/cli/ tests/cli/
+git commit -m "feat(cli): typer 入口骨架 + 子命令占位"
+```
+
+---
+
+## Task 1: `_io.py` 共享层
+
+**Files:**
+- Create: `czsc/cli/_io.py`
+- Test: `tests/cli/test_io.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_io.py`：
+```python
+import json
+
+import pytest
+import typer
+
+from czsc.cli import _io
+from czsc.mock import generate_symbol_kines
+
+
+def test_load_bars_df_csv(tmp_path):
+    df = generate_symbol_kines("000001", "30分钟", "20240101", "20240105")
+    p = tmp_path / "k.csv"
+    df.to_csv(p, index=False)
+    out = _io.load_bars_df(str(p))
+    for col in ["dt", "symbol", "open", "close", "high", "low", "vol", "amount"]:
+        assert col in out.columns
+
+
+def test_load_bars_df_missing_columns(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text("a,b\n1,2\n")
+    with pytest.raises(ValueError, match="缺少必需列"):
+        _io.load_bars_df(str(p))
+
+
+def test_emit_json(capsys):
+    _io.emit({"k": 1}, json_out=True, human=lambda d: None)
+    out = capsys.readouterr().out
+    assert json.loads(out) == {"k": 1}
+
+
+def test_fail_json_raises_exit(capsys):
+    with pytest.raises(typer.Exit):
+        _io.fail("boom", json_out=True, err_type="ValueError")
+    err = capsys.readouterr().err
+    assert json.loads(err)["error"]["message"] == "boom"
+
+
+def test_freq_to_cn():
+    assert _io.freq_to_cn("F30") == "30分钟"
+    assert _io.freq_to_cn("30分钟") == "30分钟"
+    assert _io.freq_to_cn("D") == "日线"
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_io.py -v`
+Expected: FAIL（`czsc.cli._io` 不存在）。
+
+- [ ] **Step 3: 写实现**
+
+Create `czsc/cli/_io.py`：
+```python
+"""CLI 共享层：输入加载、输出渲染、错误边界、连接器分发。"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import typer
+
+from czsc import Freq, format_standard_kline
+
+REQUIRED_OHLCV = ["dt", "symbol", "open", "close", "high", "low", "vol", "amount"]
+
+
+def freq_to_cn(freq: str) -> str:
+    """把 Freq 枚举名（F30/D…）或中文（30分钟）统一成中文频率字符串。"""
+    try:
+        return Freq[freq].value  # "F30" -> "30分钟"
+    except KeyError:
+        pass
+    # 已是中文字符串：校验其合法
+    valid = {f.value for f in Freq}
+    if freq in valid:
+        return freq
+    raise ValueError(f"无法识别的频率: {freq}；可用枚举名如 F30/D 或中文如 30分钟")
+
+
+def load_bars_df(path: str) -> pd.DataFrame:
+    """从 CSV/parquet/feather 或 stdin(-) 读标准 OHLCV DataFrame 并校验。"""
+    if path == "-":
+        df = pd.read_csv(sys.stdin)
+    else:
+        p = Path(path)
+        suffix = p.suffix.lower()
+        if suffix == ".csv":
+            df = pd.read_csv(p)
+        elif suffix in (".parquet", ".pq"):
+            df = pd.read_parquet(p)
+        elif suffix in (".feather", ".ipc"):
+            df = pd.read_feather(p)
+        else:
+            raise ValueError(f"不支持的行情文件类型: {suffix}（支持 .csv/.parquet/.feather）")
+    missing = [c for c in REQUIRED_OHLCV if c not in df.columns]
+    if missing:
+        raise ValueError(f"行情数据缺少必需列: {missing}；需要 {REQUIRED_OHLCV}")
+    df["dt"] = pd.to_datetime(df["dt"])
+    return df
+
+
+def emit(data: Any, *, json_out: bool, human: Callable[[Any], None]) -> None:
+    """统一输出：json_out 时 stdout 纯 JSON；否则调 human 渲染。"""
+    if json_out:
+        typer.echo(json.dumps(data, ensure_ascii=False, default=str))
+    else:
+        human(data)
+
+
+def fail(message: str, *, json_out: bool, err_type: str = "error", code: int = 1) -> None:
+    """统一错误：json_out → stderr JSON；否则红字；退出非零。"""
+    if json_out:
+        typer.echo(json.dumps({"error": {"type": err_type, "message": message}}, ensure_ascii=False), err=True)
+    else:
+        typer.secho(f"错误: {message}", fg=typer.colors.RED, err=True)
+    raise typer.Exit(code)
+
+
+@contextmanager
+def error_boundary(json_out: bool):
+    """命令体统一异常边界：未捕获异常 → fail()。"""
+    try:
+        yield
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001
+        fail(str(e), json_out=json_out, err_type=type(e).__name__)
+
+
+def resolve_bars_for_symbol(symbol: str, *, source: str, freq: str, sdt: str, edt: str):
+    """按 source 懒加载连接器，返回该 symbol 的 list[RawBar]。"""
+    cn = freq_to_cn(freq)
+    if source == "local":
+        from czsc.connectors import local_data
+
+        return local_data.get_raw_bars(symbol, cn, sdt, edt)
+    if source == "tushare":
+        from czsc.connectors import ts_connector
+
+        return ts_connector.get_raw_bars(symbol, cn, sdt, edt)
+    if source == "ccxt":
+        from czsc.connectors import ccxt_connector
+
+        df = ccxt_connector.get_raw_bars(symbol=symbol, period=cn, sdt=sdt, edt=edt)
+        if "symbol" not in df.columns:
+            df = df.assign(symbol=symbol)
+        return format_standard_kline(df, cn)
+    raise ValueError(f"未知数据源: {source}（支持 local/tushare/ccxt）")
+```
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_io.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/_io.py tests/cli/test_io.py
+git commit -m "feat(cli): _io 共享层（加载/渲染/错误边界/连接器分发）"
+```
+
+---
+
+## Task 2: `data` 命令组（mock / quality）
+
+**Files:**
+- Modify: `czsc/cli/data.py`
+- Test: `tests/cli/test_data.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_data.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_data_mock_writes_csv(tmp_path):
+    out = tmp_path / "k.csv"
+    r = runner.invoke(app, ["data", "mock", "--symbol", "000001", "--freq", "30分钟",
+                            "--sdt", "20240101", "--edt", "20240201", "-o", str(out)])
+    assert r.exit_code == 0, r.output
+    assert out.exists()
+    import pandas as pd
+
+    df = pd.read_csv(out)
+    assert {"dt", "symbol", "open", "close", "high", "low", "vol", "amount"} <= set(df.columns)
+
+
+def test_data_quality_json(tmp_path):
+    csv = tmp_path / "k.csv"
+    from czsc.mock import generate_symbol_kines
+
+    generate_symbol_kines("000001", "30分钟", "20240101", "20240201").to_csv(csv, index=False)
+    r = runner.invoke(app, ["data", "quality", str(csv), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "000001" in data
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_data.py -v`
+Expected: FAIL（占位 app 无 mock/quality 命令）。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/data.py`：
+```python
+"""data 子命令组：造数与质量校验。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("mock")
+def mock(
+    symbol: str = typer.Option("000001", help="标的代码"),
+    freq: str = typer.Option("30分钟", help="频率（中文或枚举名 F30）"),
+    sdt: str = typer.Option("20200101", help="起始日期"),
+    edt: str = typer.Option("20210101", help="结束日期"),
+    seed: int = typer.Option(42, help="随机种子（可复现）"),
+    output: str = typer.Option(None, "-o", "--output", help="输出 CSV 路径；缺省打印到 stdout"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """生成标准 OHLCV K 线（czsc.mock.generate_symbol_kines）。"""
+    with _io.error_boundary(json_out):
+        from czsc.mock import generate_symbol_kines
+
+        df = generate_symbol_kines(symbol, _io.freq_to_cn(freq), sdt, edt, seed=seed)
+        if output:
+            df.to_csv(output, index=False)
+            _io.emit({"output": output, "rows": len(df)}, json_out=json_out,
+                     human=lambda d: typer.echo(f"已写入 {d['output']}（{d['rows']} 行）"))
+        elif json_out:
+            typer.echo(df.to_json(orient="records", force_ascii=False, date_format="iso"))
+        else:
+            typer.echo(df.to_string(index=False))
+
+
+@app.command("quality")
+def quality(
+    input: str = typer.Argument(..., help="标准行情文件（CSV/parquet/feather）或 - 读 stdin"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """K 线质量校验（czsc.check_kline_quality）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(input)
+        report = czsc.check_kline_quality(df)
+        # rows 是 DataFrame，JSON 化只保留 description
+        slim = {
+            sym: {k: v.get("description") for k, v in checks.items()}
+            for sym, checks in report.items()
+        }
+
+        def human(d):
+            for sym, checks in d.items():
+                typer.echo(f"[{sym}]")
+                for k, desc in checks.items():
+                    typer.echo(f"  {k}: {desc}")
+
+        _io.emit(slim, json_out=json_out, human=human)
+```
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_data.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/data.py tests/cli/test_data.py
+git commit -m "feat(cli): data mock / quality"
+```
+
+---
+
+## Task 3: `signals` 命令组（list / doc）
+
+**Files:**
+- Modify: `czsc/cli/signals.py`
+- Test: `tests/cli/test_signals.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_signals.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_signals_list_json_has_entries():
+    r = runner.invoke(app, ["signals", "list", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert isinstance(data, list) and len(data) > 100
+    assert {"name", "param_template", "category", "namespace"} <= set(data[0])
+
+
+def test_signals_doc_known_name():
+    # 先取一个真实名字
+    listing = json.loads(runner.invoke(app, ["signals", "list", "--json"]).stdout)
+    name = listing[0]["name"]
+    r = runner.invoke(app, ["signals", "doc", name, "--json"])
+    assert r.exit_code == 0, r.output
+    doc = json.loads(r.stdout)
+    assert doc["name"] == name
+    assert "param_template" in doc
+
+
+def test_signals_doc_unknown_name_fails():
+    r = runner.invoke(app, ["signals", "doc", "不存在的信号xyz", "--json"])
+    assert r.exit_code != 0
+    assert json.loads(r.stderr)["error"]["message"]
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_signals.py -v`
+Expected: FAIL。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/signals.py`：
+```python
+"""signals 子命令组：信号目录与文档。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("list")
+def list_(
+    category: str = typer.Option(None, "--category", help="按 category 过滤"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """列出全部信号函数（czsc._native.list_all_signals）。"""
+    with _io.error_boundary(json_out):
+        import czsc._native as native
+
+        items = native.list_all_signals()
+        if category:
+            items = [it for it in items if it.get("category") == category]
+
+        def human(rows):
+            for it in rows:
+                typer.echo(f"{it['name']:40s} [{it['category']}] {it['param_template']}")
+            typer.echo(f"共 {len(rows)} 个信号")
+
+        _io.emit(items, json_out=json_out, human=human)
+
+
+@app.command("doc")
+def doc(
+    name: str = typer.Argument(..., help="信号函数名"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """单个信号的参数模板与分类（来自 list_all_signals 条目）。"""
+    with _io.error_boundary(json_out):
+        import czsc._native as native
+
+        entry = next((it for it in native.list_all_signals() if it["name"] == name), None)
+        if entry is None:
+            raise ValueError(f"未找到信号: {name}")
+
+        def human(d):
+            typer.echo(f"名称: {d['name']}")
+            typer.echo(f"分类: {d['category']}  命名空间: {d['namespace']}")
+            typer.echo(f"参数模板: {d['param_template']}")
+
+        _io.emit(entry, json_out=json_out, human=human)
+```
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_signals.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/signals.py tests/cli/test_signals.py
+git commit -m "feat(cli): signals list / doc"
+```
+
+---
+
+## Task 4: `analyze` 命令
+
+**Files:**
+- Modify: `czsc/cli/analyze.py`
+- Test: `tests/cli/test_analyze.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_analyze.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _mock_csv(tmp_path):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / "k.csv"
+    generate_symbol_kines("000001", "30分钟", "20230101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_analyze_json_has_fx_and_bi(tmp_path):
+    p = _mock_csv(tmp_path)
+    r = runner.invoke(app, ["analyze", str(p), "--freq", "30分钟", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert data["symbol"] == "000001"
+    assert len(data["fx_list"]) > 0
+    assert len(data["bi_list"]) > 0
+    assert {"dt", "mark", "fx"} <= set(data["fx_list"][0])
+    assert {"sdt", "edt", "direction", "high", "low"} <= set(data["bi_list"][0])
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_analyze.py -v`
+Expected: FAIL。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/analyze.py`：
+```python
+"""analyze 命令：对一段 K 线跑缠论，输出分型 + 笔。"""
+
+from __future__ import annotations
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer()
+
+
+def _fx_to_dict(fx) -> dict:
+    return {
+        "dt": fx.dt,
+        "mark": str(fx.mark),
+        "fx": fx.fx,
+        "high": fx.high,
+        "low": fx.low,
+        "power_str": getattr(fx, "power_str", None),
+    }
+
+
+def _bi_to_dict(bi) -> dict:
+    return {
+        "sdt": bi.sdt,
+        "edt": bi.edt,
+        "direction": str(bi.direction),
+        "high": bi.high,
+        "low": bi.low,
+        "length": bi.length,
+        "power": bi.power,
+    }
+
+
+def analyze(
+    input: str = typer.Argument(..., help="标准行情文件（CSV/parquet/feather）或 - 读 stdin"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率（中文或枚举名 F30）"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """缠论分型 + 笔识别（czsc.CZSC）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+
+        df = _io.load_bars_df(input)
+        cn = _io.freq_to_cn(freq)
+        bars = format_standard_kline(df, cn)
+        c = CZSC(bars)
+        out = {
+            "symbol": c.symbol,
+            "freq": cn,
+            "bars": len(c.bars_raw),
+            "fx_list": [_fx_to_dict(fx) for fx in c.fx_list],
+            "bi_list": [_bi_to_dict(bi) for bi in c.bi_list],
+        }
+
+        def human(d):
+            typer.echo(f"{d['symbol']} {d['freq']}  bars={d['bars']}  "
+                       f"分型={len(d['fx_list'])}  笔={len(d['bi_list'])}")
+            for bi in d["bi_list"][-5:]:
+                typer.echo(f"  笔 {bi['direction']} {bi['sdt']}~{bi['edt']} "
+                           f"[{bi['low']:.2f},{bi['high']:.2f}] len={bi['length']}")
+
+        _io.emit(out, json_out=json_out, human=human)
+```
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_analyze.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/analyze.py tests/cli/test_analyze.py
+git commit -m "feat(cli): analyze（分型+笔）"
+```
+
+---
+
+## Task 5: `backtest` 命令（核心）
+
+**Files:**
+- Modify: `czsc/cli/backtest.py`
+- Test: `tests/cli/test_backtest.py`、`tests/cli/conftest.py`（Position fixture）
+
+- [ ] **Step 1: 写 Position fixture（测试基础设施）**
+
+Create `tests/cli/conftest.py`：
+```python
+import pytest
+
+from czsc import Event, Position
+
+
+@pytest.fixture
+def position_file(tmp_path):
+    """构造一个 unique_signals 非空的真实 Position，落盘为 JSON 文件，返回路径。"""
+    oe = Event.load({"operate": "开多", "signals_all": ["30分钟_D1_表里关系V230101_向上_任意_任意_0"]})
+    xe = Event.load({"operate": "平多", "signals_all": ["30分钟_D1_表里关系V230101_向下_任意_任意_0"]})
+    pos = Position(symbol="000001", name="表里多头", opens=[oe], exits=[xe],
+                   interval=0, timeout=20, stop_loss=300)
+    p = tmp_path / "pos.json"
+    p.write_text(pos.to_json())
+    return p
+```
+
+- [ ] **Step 2: 写失败的测试**
+
+Create `tests/cli/test_backtest.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path, symbol="000001"):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / f"{symbol}.csv"
+    generate_symbol_kines(symbol, "30分钟", "20200101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_backtest_with_bars_file_json(tmp_path, position_file):
+    bars = _bars_csv(tmp_path)
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(bars), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "symbols" in data and "portfolio" in data
+    assert "000001" in data["symbols"]
+    assert "年化收益" in data["portfolio"]
+
+
+def test_backtest_html_report(tmp_path, position_file):
+    bars = _bars_csv(tmp_path)
+    out = tmp_path / "report.html"
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(bars),
+                            "--html", str(out), "--json"])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_backtest_requires_data_source(position_file):
+    r = runner.invoke(app, ["backtest", str(position_file), "--json"])
+    assert r.exit_code != 0
+    assert json.loads(r.stderr)["error"]["message"]
+```
+
+- [ ] **Step 3: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_backtest.py -v`
+Expected: FAIL。
+
+- [ ] **Step 4: 写实现**
+
+Replace `czsc/cli/backtest.py`：
+```python
+"""backtest 命令：传入 Position 对象 + 数据源，产出回测结果。"""
+
+from __future__ import annotations
+
+import pandas as pd
+import typer
+
+from czsc import CzscStrategyBase, Position, WeightBacktest, format_standard_kline
+from czsc.cli import _io
+
+app = typer.Typer()
+
+
+class _PositionsStrategy(CzscStrategyBase):
+    """把外部传入的 positions 注入抽象基类（基类 positions 为抽象属性）。"""
+
+    def __init__(self, position_list, **kwargs):
+        self._position_list = position_list
+        super().__init__(**kwargs)
+
+    @property
+    def positions(self):
+        return self._position_list
+
+
+def _holds_to_weight(holds: pd.DataFrame) -> pd.DataFrame:
+    """holds_df -> 权重表 {dt,symbol,weight,price}；多 position 按 (dt,symbol) 等权聚合。"""
+    return (
+        holds.groupby(["dt", "symbol"], as_index=False)
+        .agg(weight=("pos", "mean"), price=("price", "first"))
+    )
+
+
+def _backtest_symbol(positions, bars, symbol: str) -> pd.DataFrame:
+    strat = _PositionsStrategy(positions, symbol=symbol)
+    res = strat.backtest(bars)
+    return _holds_to_weight(res.holds_df())
+
+
+def backtest(
+    positions: list[str] = typer.Argument(..., help="一个或多个 Position JSON 文件"),
+    symbol: list[str] = typer.Option(None, "--symbol", help="标的（可重复或逗号分隔，支持多 symbol）"),
+    source: str = typer.Option("local", "--source", help="数据源 local/tushare/ccxt"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    sdt: str = typer.Option("20200101", "--sdt", help="起始日期"),
+    edt: str = typer.Option("20240101", "--edt", help="结束日期"),
+    bars_file: str = typer.Option(None, "--bars", help="标准行情文件（可含多 symbol）；与 --symbol 二选一"),
+    html: str = typer.Option(None, "--html", help="生成 wbt HTML 回测报告路径"),
+    output: str = typer.Option(None, "-o", "--output", help="结果 JSON 落盘路径"),
+    fee_rate: float = typer.Option(2e-4, "--fee-rate", help="手续费率"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """positions + 数据源 → 逐 symbol 回测 + 组合聚合（czsc 回测 + WeightBacktest）。"""
+    with _io.error_boundary(json_out):
+        pos_objs = [Position.from_json(open(p, encoding="utf-8").read()) for p in positions]
+
+        # 解析数据源：bars 文件（可多 symbol）或 symbol 列表 × 连接器
+        weight_frames: dict[str, pd.DataFrame] = {}
+        if bars_file:
+            df = _io.load_bars_df(bars_file)
+            for sym, g in df.groupby("symbol"):
+                bars = format_standard_kline(g, _io.freq_to_cn(freq))
+                weight_frames[str(sym)] = _backtest_symbol(pos_objs, bars, str(sym))
+        else:
+            syms: list[str] = []
+            for s in symbol or []:
+                syms.extend(x for x in s.split(",") if x)
+            if not syms:
+                raise ValueError("必须提供 --symbol（可多个）或 --bars 行情文件之一")
+            for sym in syms:
+                bars = _io.resolve_bars_for_symbol(sym, source=source, freq=freq, sdt=sdt, edt=edt)
+                weight_frames[sym] = _backtest_symbol(pos_objs, bars, sym)
+
+        # 逐 symbol + 组合绩效
+        per_symbol = {sym: WeightBacktest(w, fee_rate=fee_rate).stats for sym, w in weight_frames.items()}
+        portfolio_w = pd.concat(weight_frames.values(), ignore_index=True)
+        portfolio = WeightBacktest(portfolio_w, fee_rate=fee_rate).stats
+
+        if html:
+            from wbt import generate_backtest_report
+
+            generate_backtest_report(portfolio_w, output_path=html, title="CZSC 回测报告")
+
+        result = {"symbols": per_symbol, "portfolio": portfolio, "html": html}
+        if output:
+            import json as _json
+
+            open(output, "w", encoding="utf-8").write(_json.dumps(result, ensure_ascii=False, default=str))
+
+        def human(d):
+            typer.echo("== 组合绩效 ==")
+            for k in ["年化收益", "夏普比率", "最大回撤", "日胜率"]:
+                typer.echo(f"  {k}: {d['portfolio'].get(k)}")
+            for sym, st in d["symbols"].items():
+                typer.echo(f"  [{sym}] 年化={st.get('年化收益')} 夏普={st.get('夏普比率')}")
+            if d["html"]:
+                typer.echo(f"HTML 报告: {d['html']}")
+
+        _io.emit(result, json_out=json_out, human=human)
+```
+
+- [ ] **Step 5: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_backtest.py -v`
+Expected: PASS（三个用例）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add czsc/cli/backtest.py tests/cli/test_backtest.py tests/cli/conftest.py
+git commit -m "feat(cli): backtest（positions+数据源→逐symbol回测+组合+HTML）"
+```
+
+---
+
+## Task 6: `research` 命令组（run / replay / config）
+
+**Files:**
+- Modify: `czsc/cli/research.py`
+- Test: `tests/cli/test_research.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_research.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_research_config_derives(tmp_path):
+    r = runner.invoke(app, ["research", "config",
+                            "30分钟_D1_表里关系V230101_向上_任意_任意_0", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "signals_config" in data and "freqs" in data
+    assert data["freqs"] == ["30分钟"]
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_research.py -v`
+Expected: FAIL。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/research.py`：
+```python
+"""research 子命令组：研究 / 回放 / 配置解析。"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("config")
+def config(
+    signals: list[str] = typer.Argument(..., help="一个或多个信号字符串"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """由信号序列派生 signals_config 与所需频率。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        sc = czsc.get_signals_config(list(signals))
+        freqs = czsc.get_signals_freqs(sc)
+        out = {"signals_config": sc, "freqs": freqs}
+        _io.emit(out, json_out=json_out,
+                 human=lambda d: typer.echo(json.dumps(d, ensure_ascii=False, indent=2)))
+
+
+@app.command("run")
+def run(
+    bars: str = typer.Argument(..., help="标准行情文件"),
+    strategy: str = typer.Argument(..., help="strategy.json（含 symbol/positions/signals_config）"),
+    sdt: str = typer.Option(None, "--sdt", help="起始时间覆盖"),
+    output: str = typer.Option(None, "-o", "--output", help="结果 JSON 落盘路径"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """内存研究（czsc.run_research）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(bars)
+        strat = json.loads(open(strategy, encoding="utf-8").read())
+        res = czsc.run_research(df, strat, sdt=sdt)
+        out = {"meta": res.meta}
+        if output:
+            res.holds_df().to_csv(output, index=False)
+            out["holds_csv"] = output
+        _io.emit(out, json_out=json_out, human=lambda d: typer.echo(json.dumps(d, ensure_ascii=False, indent=2)))
+
+
+@app.command("replay")
+def replay(
+    bars: str = typer.Argument(..., help="标准行情文件"),
+    strategy: str = typer.Argument(..., help="strategy.json"),
+    res_path: str = typer.Option(..., "-o", "--output", help="回放结果落盘目录"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """落盘回放（czsc.run_replay）。"""
+    with _io.error_boundary(json_out):
+        import czsc
+
+        df = _io.load_bars_df(bars)
+        strat = json.loads(open(strategy, encoding="utf-8").read())
+        res = czsc.run_replay(df, strat, res_path=res_path)
+        _io.emit({"meta": getattr(res, "meta", {}), "res_path": res_path}, json_out=json_out,
+                 human=lambda d: typer.echo(f"回放完成 → {d['res_path']}"))
+```
+
+注：`run_replay` 的精确签名在 Task 实施时用 `uv run --no-sync python -c "import inspect,czsc;print(inspect.signature(czsc.run_replay))"` 确认；若 `res_path` 形参名不同，相应调整关键字。
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_research.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/research.py tests/cli/test_research.py
+git commit -m "feat(cli): research run / replay / config"
+```
+
+---
+
+## Task 7: `plot` 命令组（czsc / trader / signals）
+
+**Files:**
+- Modify: `czsc/cli/plot.py`
+- Test: `tests/cli/test_plot.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_plot.py`：
+```python
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / "k.csv"
+    generate_symbol_kines("000001", "30分钟", "20230101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_plot_czsc_writes_html(tmp_path):
+    p = _bars_csv(tmp_path)
+    out = tmp_path / "c.html"
+    r = runner.invoke(app, ["plot", "czsc", str(p), "--freq", "30分钟", "-o", str(out)])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_plot_signals_writes_html(tmp_path):
+    p = _bars_csv(tmp_path)
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('[{"name": "30分钟_D1_表里关系V230101_向上_任意_任意_0"}]')
+    out = tmp_path / "s.html"
+    r = runner.invoke(app, ["plot", "signals", str(p), "--signals-config", str(cfg),
+                            "--freq", "30分钟", "-o", str(out)])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_plot.py -v`
+Expected: FAIL。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/plot.py`：
+```python
+"""plot 子命令组：缠论 / 信号 HTML 可视化。"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command("czsc")
+def czsc_cmd(
+    input: str = typer.Argument(..., help="标准行情文件"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    output: str = typer.Option("czsc.html", "-o", "--output", help="HTML 输出路径"),
+    theme: str = typer.Option("light", "--theme", help="light/dark"),
+    tail_bars: int = typer.Option(None, "--tail-bars", help="只画最后 N 根"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """单周期缠论结构 HTML（plot_czsc）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+        from czsc.utils.plotting.lightweight import plot_czsc
+
+        df = _io.load_bars_df(input)
+        c = CZSC(format_standard_kline(df, _io.freq_to_cn(freq)))
+        plot_czsc(c, output="html", path=output, theme=theme, tail_bars=tail_bars)
+        _io.emit({"output": output}, json_out=json_out,
+                 human=lambda d: typer.echo(f"已写入 {d['output']}"))
+
+
+@app.command("signals")
+def signals_cmd(
+    input: str = typer.Argument(..., help="标准行情文件"),
+    signals_config: str = typer.Option(..., "--signals-config", help="signals_config JSON 文件"),
+    freq: str = typer.Option("30分钟", "--freq", help="频率"),
+    output: str = typer.Option("signals.html", "-o", "--output", help="HTML 输出路径"),
+    sdt: str = typer.Option("20170101", "--sdt", help="信号起始日期"),
+    tail_bars: int = typer.Option(None, "--tail-bars", help="只画最后 N 根"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """信号叠加到 K 线主图 HTML（plot_czsc_signals）。"""
+    with _io.error_boundary(json_out):
+        from czsc import format_standard_kline
+        from czsc.utils.plotting.lightweight import plot_czsc_signals
+
+        df = _io.load_bars_df(input)
+        bars = format_standard_kline(df, _io.freq_to_cn(freq))
+        cfg = json.loads(open(signals_config, encoding="utf-8").read())
+        plot_czsc_signals(bars, signals_config=cfg, output="html", path=output,
+                          sdt=sdt, tail_bars=tail_bars)
+        _io.emit({"output": output}, json_out=json_out,
+                 human=lambda d: typer.echo(f"已写入 {d['output']}"))
+```
+
+注：`plot trader` 需要构造 `CzscTrader` 对象（依赖 strategy + bars），实现复杂度高于本计划其它命令，**v1 先实现 `plot czsc` 与 `plot signals`**（覆盖案例 2 单周期 + 案例 3）；`plot trader`（案例 2 多周期）作为后续增量，实现时参考 `docs/examples/13_lightweight_charts_html.py` 构造 trader 后调 `plot_czsc_trader`。
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_plot.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/plot.py tests/cli/test_plot.py
+git commit -m "feat(cli): plot czsc / signals（案例 2、3）"
+```
+
+---
+
+## Task 8: `bench` 命令
+
+**Files:**
+- Modify: `czsc/cli/bench.py`
+- Test: `tests/cli/test_bench.py`
+
+- [ ] **Step 1: 先确认 examples/17 的可复用入口**
+
+Run: `uv run --no-sync python -c "import ast,sys; print(open('docs/examples/17_perf_benchmark.py').read()[:2000])"`
+目标：确认其有无可直接 import 的函数；若无（纯 `__main__` 脚本），则在 bench 命令内**内联最小版**：mock 生成 N 年 K 线 → 计时 `CZSC(bars)` 构造 + 逐根 `c.update(bar)` → 输出 bars/s。
+
+- [ ] **Step 2: 写失败的测试**
+
+Create `tests/cli/test_bench.py`：
+```python
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.slow
+def test_bench_json_reports_throughput():
+    r = runner.invoke(app, ["bench", "--years", "1", "--freq", "30分钟", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert data["czsc_construct"]["bars_per_sec"] > 0
+```
+
+- [ ] **Step 3: 跑测试，确认 fail（带 --run-slow）**
+
+Run: `uv run --no-sync pytest tests/cli/test_bench.py -v --run-slow`
+Expected: FAIL。
+
+- [ ] **Step 4: 写实现**
+
+Replace `czsc/cli/bench.py`：
+```python
+"""bench 命令：CZSC 吞吐量基准（沿用 examples/17 逻辑）。"""
+
+from __future__ import annotations
+
+import time
+
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer()
+
+
+def bench(
+    years: int = typer.Option(20, "--years", help="模拟数据年数"),
+    freq: str = typer.Option("5分钟", "--freq", help="频率"),
+    symbol: str = typer.Option("000001", "--symbol", help="标的"),
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """本地复现 CZSC 单周期吞吐量（bars/s）。"""
+    with _io.error_boundary(json_out):
+        from czsc import CZSC, format_standard_kline
+        from czsc.mock import generate_symbol_kines
+
+        end_year = 2024
+        sdt = f"{end_year - years:04d}0101"
+        edt = f"{end_year:04d}0101"
+        df = generate_symbol_kines(symbol, _io.freq_to_cn(freq), sdt, edt)
+        bars = format_standard_kline(df, _io.freq_to_cn(freq))
+        n = len(bars)
+
+        t0 = time.perf_counter()
+        c = CZSC(bars)
+        construct_sec = time.perf_counter() - t0
+
+        t1 = time.perf_counter()
+        c2 = CZSC(bars[:1])
+        for bar in bars[1:]:
+            c2.update(bar)
+        update_sec = time.perf_counter() - t1
+
+        out = {
+            "symbol": symbol,
+            "freq": _io.freq_to_cn(freq),
+            "bars": n,
+            "czsc_construct": {"sec": round(construct_sec, 4), "bars_per_sec": round(n / construct_sec)},
+            "czsc_update": {"sec": round(update_sec, 4), "bars_per_sec": round(n / update_sec)},
+        }
+
+        def human(d):
+            typer.echo(f"{d['symbol']} {d['freq']}  bars={d['bars']}")
+            typer.echo(f"  构造:   {d['czsc_construct']['bars_per_sec']:>10,} bars/s")
+            typer.echo(f"  增量推进:{d['czsc_update']['bars_per_sec']:>10,} bars/s")
+
+        _io.emit(out, json_out=json_out, human=human)
+```
+
+- [ ] **Step 5: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_bench.py -v --run-slow`
+Expected: PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add czsc/cli/bench.py tests/cli/test_bench.py
+git commit -m "feat(cli): bench（CZSC 吞吐量基准，案例 4）"
+```
+
+---
+
+## Task 9: `schema` 元命令
+
+**Files:**
+- Modify: `czsc/cli/schema.py`
+- Test: `tests/cli/test_schema.py`
+
+- [ ] **Step 1: 写失败的测试**
+
+Create `tests/cli/test_schema.py`：
+```python
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_schema_json_lists_commands():
+    r = runner.invoke(app, ["schema", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    cmds = {c["command"] for c in data}
+    assert "czsc signals list" in cmds
+    assert "czsc backtest" in cmds
+    entry = next(c for c in data if c["command"] == "czsc signals list")
+    assert any(p["name"] == "json_out" or p.get("opts") for p in entry["params"]) or entry["params"]
+```
+
+- [ ] **Step 2: 跑测试，确认 fail**
+
+Run: `uv run --no-sync pytest tests/cli/test_schema.py -v`
+Expected: FAIL。
+
+- [ ] **Step 3: 写实现**
+
+Replace `czsc/cli/schema.py`：
+```python
+"""schema 元命令：内省 typer app，吐出全部命令/参数 schema 供 LLM 自发现。"""
+
+from __future__ import annotations
+
+import click
+import typer
+
+from czsc.cli import _io
+
+app = typer.Typer()
+
+
+def _walk(cmd, prefix):
+    out = []
+    if isinstance(cmd, click.Group):
+        for name, sub in cmd.commands.items():
+            out += _walk(sub, prefix + [name])
+    else:
+        params = []
+        for p in cmd.params:
+            params.append(
+                {
+                    "name": p.name,
+                    "opts": list(getattr(p, "opts", [])),
+                    "type": getattr(p.type, "name", str(p.type)),
+                    "required": bool(p.required),
+                    "is_flag": bool(getattr(p, "is_flag", False)),
+                    "default": p.default if not callable(p.default) else None,
+                    "help": getattr(p, "help", None),
+                }
+            )
+        out.append({"command": " ".join(prefix), "help": (cmd.help or "").strip(), "params": params})
+    return out
+
+
+def schema(
+    json_out: bool = typer.Option(False, "--json", help="JSON 输出"),
+) -> None:
+    """导出全部子命令与参数 schema。"""
+    with _io.error_boundary(json_out):
+        from czsc.cli import app as root_app
+
+        cmd = typer.main.get_command(root_app)
+        data = _walk(cmd, ["czsc"])
+
+        def human(rows):
+            for c in rows:
+                typer.echo(f"{c['command']}  —  {c['help']}")
+                for p in c["params"]:
+                    typer.echo(f"    {p['opts'] or [p['name']]}  ({p['type']})  {p['help'] or ''}")
+
+        _io.emit(data, json_out=json_out, human=human)
+```
+
+- [ ] **Step 4: 跑测试，确认 pass**
+
+Run: `uv run --no-sync pytest tests/cli/test_schema.py -v`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add czsc/cli/schema.py tests/cli/test_schema.py
+git commit -m "feat(cli): schema 元命令（LLM 自发现）"
+```
+
+---
+
+## Task 10: 全量验收（acceptance）
+
+**Files:**
+- Create: `tests/cli/test_acceptance.py`
+
+- [ ] **Step 1: 写端到端验收测试**
+
+Create `tests/cli/test_acceptance.py`：
+```python
+"""端到端验收：模拟 LLM 用 schema 发现 → 调用核心命令全链路。"""
+
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_schema_then_call_chain(tmp_path, position_file):
+    # 1. schema 自发现
+    schema = json.loads(runner.invoke(app, ["schema", "--json"]).stdout)
+    cmds = {c["command"] for c in schema}
+    assert {"czsc signals list", "czsc analyze", "czsc backtest", "czsc data mock"} <= cmds
+
+    # 2. 造数
+    csv = tmp_path / "k.csv"
+    r = runner.invoke(app, ["data", "mock", "--symbol", "000001", "--freq", "30分钟",
+                            "--sdt", "20200101", "--edt", "20240101", "-o", str(csv)])
+    assert r.exit_code == 0
+
+    # 3. analyze
+    a = json.loads(runner.invoke(app, ["analyze", str(csv), "--freq", "30分钟", "--json"]).stdout)
+    assert a["fx_list"] and a["bi_list"]
+
+    # 4. backtest
+    b = json.loads(runner.invoke(app, ["backtest", str(position_file), "--bars", str(csv), "--json"]).stdout)
+    assert "年化收益" in b["portfolio"]
+```
+
+- [ ] **Step 2: 跑全套 CLI 测试**
+
+Run: `uv run --no-sync pytest tests/cli/ -v`
+Expected: 全部 PASS（bench 默认跳过）。
+
+- [ ] **Step 3: 跑全仓回归 + ruff**
+
+Run:
+```bash
+uv run --no-sync pytest -q
+uv run --no-sync ruff check czsc/cli/ tests/cli/
+uv run --no-sync ruff format --check czsc/cli/ tests/cli/
+```
+Expected: 测试无回归；ruff 无报错（有则 `ruff format czsc/cli/ tests/cli/` 修复后重跑）。
+
+- [ ] **Step 4: 验证 console_scripts 真入口**
+
+Run:
+```bash
+uv run --no-sync python -c "from czsc.cli import app; import typer; typer.main.get_command(app)"
+uv run --no-sync czsc schema --json | python -c "import sys,json; print(len(json.load(sys.stdin)), 'commands')"
+```
+Expected: `czsc` 命令可用，schema 输出 ≥ 9 条命令。
+
+- [ ] **Step 5: 慢测试全量**
+
+Run: `uv run --no-sync pytest tests/cli/ --run-slow -q`
+Expected: 含 bench 全 PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/cli/test_acceptance.py
+git commit -m "test(cli): 端到端验收（schema 发现 → 全链路调用）"
+```
+
+---
+
+## 自检（plan reviewer 已内联修正）
+
+- **spec 覆盖**：signals list/doc（T3）、analyze（T4）、backtest+案例1（T5）、research run/replay/config（T6）、data mock/quality（T2）、plot czsc/signals+案例2/3（T7，`plot trader` 标注为后续增量）、bench+案例4（T8）、schema（T9）、打包入口（T0）、I/O 约定（T1）、验收（T10）。✅
+- **placeholder 扫描**：每步均有真实代码与精确命令；`run_replay` 签名、examples/17 入口标注为「实施时用一行命令确认」，非 placeholder（给了确认命令与兜底方案）。
+- **类型一致性**：`_io.emit/fail/error_boundary/load_bars_df/freq_to_cn/resolve_bars_for_symbol` 在 T1 定义，后续 task 一致引用；`_PositionsStrategy` 仅 T5 内部使用。
+
+## 已知后续增量（非 v1 阻塞）
+
+- `plot trader`（案例 2 多周期联立）：需构造 `CzscTrader`，参考 `docs/examples/13_lightweight_charts_html.py`。
+- backtest 多 position 权重聚合口径目前为等权 mean；如需市值/自定义加权，后续加 `--weight-agg` 选项。
+- `--symbol` 真实连接器（tushare/ccxt）需各自 token/网络，CI 用 `--bars` 文件路径覆盖；连接器路径用 `@pytest.mark.slow` + 真实凭证在本地验证。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,11 @@ dependencies = [
     "loguru",
     "dill",
     "tenacity",
+    "typer>=0.12.0",
 ]
+
+[project.scripts]
+czsc = "czsc.cli:app"
 
 [[tool.uv.index]]
 url = "https://pypi.python.org/simple"
@@ -145,6 +149,10 @@ extend-exclude = ["czsc/_native/__init__.pyi"]
 select = ["E", "F", "I", "UP", "B", "SIM", "C4"]
 ignore = ["E501", "SIM112"]
 extend-safe-fixes = ["UP"]
+
+[tool.ruff.lint.flake8-bugbear]
+# typer 的惯用法：Argument/Option 作为参数默认值的工厂调用，B008 应放行
+extend-immutable-calls = ["typer.Argument", "typer.Option"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["czsc"]

--- a/scripts/sector_purity_analysis.py
+++ b/scripts/sector_purity_analysis.py
@@ -1,0 +1,539 @@
+"""同花顺概念板块「成分股纯度」分析。
+
+做交易要做龙头，龙头分行业 / 分板块；第一步是找出成分股纯度高的板块——即板块内
+个股是否被同一条主线（共同因子）驱动、是否齐涨齐跌。本脚本对每个同花顺概念板块的
+成分股日收益做纯度打分（0~100，越高越纯），并汇总成一份自包含 HTML 报告。
+
+两版打分指标（均来自任务文档）：
+
+1. 第一主成分解释力 / Absorption Ratio（最贴本质，最推荐）
+   对标准化后的收益矩阵 R̃ 做 PCA，第一主成分解释方差占比 λ₁ / Σλ 即为板块凝聚度。
+       score1 = (λ₁ / Σλ) × 100
+   含义：板块是否被单一共同因子驱动——这正是「板块作为一个整体」的数学定义，
+   也是金融文献里 Absorption Ratio（系统性风险 / 板块凝聚度）的标准做法。
+
+2. 齐涨齐跌方向一致性（无需相关矩阵，极快、对异常股不敏感）
+   每个交易日 t：方向一致率 c_t = max(上涨股占比, 下跌股占比)，取 T 天平均 c̄。
+   随机情形下 c̄ 期望约 0.6（不是 0.5），故按 0.55 重标定：
+       score2 = clip((c̄ - 0.55) / (1 - 0.55), 0, 1) × 100
+
+数据流（关键优化）：
+   同花顺概念板块约 400+ 个、成分股并集近全市场（~5000 只）。逐股取日线需要数千次
+   API 调用；本脚本改为「按交易日取全市场日线」——T 个交易日仅 T 次调用，再透视成
+   收益矩阵（日期 × ts_code），各板块只需在矩阵上切列即可，省时且充分利用磁盘缓存。
+
+用法：
+    # 默认最近 250 个交易日，处理全部概念板块
+    uv run --no-sync python scripts/sector_purity_analysis.py
+
+    # 指定窗口 + 仅跑前 20 个板块（快速验证）
+    uv run --no-sync python scripts/sector_purity_analysis.py --start 20240101 --end 20241231 --limit 20
+
+    # 自定义输出目录
+    uv run --no-sync python scripts/sector_purity_analysis.py --output-dir ~/sector_purity
+
+TUSHARE_TOKEN 从环境变量或项目根目录 .env 读取。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from loguru import logger
+from tqdm import tqdm
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# ---- 默认参数（模块级常量，避免魔法值）-------------------------------------
+TUSHARE_URL = "http://api.tushare.pro"
+# 同花顺指数类型（ths_index 的 type 参数）-> 中文标签
+INDEX_TYPE_LABELS = {"N": "概念", "I": "行业", "R": "地域", "S": "特色", "ST": "风格", "TH": "主题", "BB": "宽基"}
+DEFAULT_DAYS = 250  # 未显式给定起止日期时，回看的交易日数量
+MIN_MEMBERS = 5  # 板块有效成分股下限，少于此数不计算
+MIN_OBS_DAYS = 60  # 收益序列最少观测天数
+MAX_MISSING_RATIO = 0.30  # 单只成分股窗口内缺失比例上限，超过则剔除
+DIRECTION_BASELINE = 0.55  # 齐涨齐跌随机基准（重标定锚点）
+THS_MEMBER_INTERVAL = 0.14  # ths_member 调用间隔（秒），约 430 次/分钟，规避 500 次/分钟限频
+THS_MEMBER_RETRY_SLEEP = 5  # 限频失败后的退避等待（秒）
+# 重试次数。节流已能规避限频，且大量行业指数（如 700/861 前缀）本就无成分数据，
+# 对空结果重试纯属浪费，故默认 0；如遇限频可临时调大。
+THS_MEMBER_RETRIES = 0
+CACHE_PATH = os.path.expanduser("~/.quant_data_cache")
+
+
+# ============================================================================
+# 数据获取
+# ============================================================================
+def _load_dotenv(root: Path) -> None:
+    """把项目根目录 .env 里的键值写入环境变量（不覆盖已存在的）。"""
+    env_file = root / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def build_client(token: str | None):
+    """构造带磁盘缓存的 Tushare DataClient。"""
+    from czsc import DataClient
+
+    token = token or os.environ.get("TUSHARE_TOKEN")
+    if not token:
+        logger.error("未找到 TUSHARE_TOKEN，请在 .env 或环境变量中设置")
+        sys.exit(1)
+    return DataClient(token=token, url=TUSHARE_URL, cache_path=CACHE_PATH)
+
+
+def resolve_trade_dates(dc, start: str | None, end: str | None, days: int) -> list[str]:
+    """返回窗口内的交易日列表（升序，YYYYMMDD）。
+
+    显式给定 start/end 时取区间内全部交易日；否则取截至 end（默认今天）最近 days 个交易日。
+    """
+    end = end or datetime.now().strftime("%Y%m%d")
+    cal_start = start or (datetime.strptime(end, "%Y%m%d") - timedelta(days=int(days * 2.2) + 60)).strftime("%Y%m%d")
+    cal = dc.trade_cal(exchange="SSE", start_date=cal_start, end_date=end, is_open="1")
+    trade_dates = sorted(cal["cal_date"].astype(str).tolist())
+    if not start:
+        trade_dates = trade_dates[-days:]
+    return trade_dates
+
+
+def fetch_concept_list(dc, index_type: str, limit: int | None) -> pd.DataFrame:
+    """获取同花顺指定类型的板块列表（type=N 概念 / I 行业 ...）。"""
+    idx = dc.ths_index(type=index_type)
+    idx = idx.dropna(subset=["ts_code"]).reset_index(drop=True)
+    if limit:
+        idx = idx.head(limit).copy()
+    logger.info(f"{INDEX_TYPE_LABELS.get(index_type, index_type)}板块数量：{len(idx)}")
+    return idx
+
+
+def _ths_member_with_retry(dc, code: str, retries: int = THS_MEMBER_RETRIES):
+    """获取单个板块成分股，遇限频（40203）/空结果时退避重试。"""
+    mem = None
+    for attempt in range(retries + 1):
+        try:
+            mem = dc.ths_member(ts_code=code)
+        except Exception:  # noqa: BLE001
+            mem = None
+        if mem is not None and not mem.empty:
+            return mem
+        if attempt < retries:
+            time.sleep(THS_MEMBER_RETRY_SLEEP)  # 等待限频窗口恢复
+    return mem
+
+
+def fetch_members(dc, concept_codes: list[str]) -> dict[str, list[str]]:
+    """逐板块获取成分股，返回 {板块代码: [成分股 ts_code, ...]}。
+
+    ths_member 限频 500 次/分钟，板块数可能上千（行业指数），故每次调用间隔节流，
+    并对限频失败做退避重试；命中磁盘缓存时不触发网络请求。
+    """
+    members: dict[str, list[str]] = {}
+    for code in tqdm(concept_codes, desc="拉取板块成分股"):
+        mem = _ths_member_with_retry(dc, code)
+        time.sleep(THS_MEMBER_INTERVAL)  # 节流，规避 500 次/分钟限频
+        if mem is None or mem.empty or "con_code" not in mem.columns:
+            logger.warning(f"{code} 成分股为空 / 获取失败，跳过")
+            continue
+        members[code] = mem["con_code"].dropna().unique().tolist()
+    return members
+
+
+def fetch_return_matrix(dc, trade_dates: list[str], universe: set[str]) -> pd.DataFrame:
+    """按交易日取全市场日线，透视成收益矩阵（index=日期, columns=ts_code, value=日收益）。
+
+    日收益 = pct_chg / 100（pct_chg 已对除权除息做了 pre_close 调整）。
+    """
+    frames = []
+    for d in tqdm(trade_dates, desc="拉取全市场日线"):
+        try:
+            day = dc.daily(trade_date=d, fields="ts_code,trade_date,pct_chg")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"{d} 日线获取失败：{e}")
+            continue
+        if day is None or day.empty:
+            continue
+        day = day[day["ts_code"].isin(universe)]
+        frames.append(day[["trade_date", "ts_code", "pct_chg"]])
+
+    if not frames:
+        return pd.DataFrame()
+
+    raw = pd.concat(frames, ignore_index=True)
+    raw["ret"] = raw["pct_chg"].astype(float) / 100.0
+    matrix = raw.pivot_table(index="trade_date", columns="ts_code", values="ret")
+    matrix = matrix.sort_index()
+    return matrix
+
+
+# ============================================================================
+# 纯度打分
+# ============================================================================
+def _clean_block(returns: pd.DataFrame) -> pd.DataFrame:
+    """剔除缺失过多 / 零波动的成分股列，返回可用于打分的子矩阵。"""
+    if returns.empty:
+        return returns
+    keep = returns.columns[returns.isna().mean() <= MAX_MISSING_RATIO]
+    block = returns[keep]
+    # 缺失天数较少的留下，剩余缺口按 0 填充（停牌当日视为零收益）
+    block = block.dropna(axis=1, thresh=int(len(block) * (1 - MAX_MISSING_RATIO))).fillna(0.0)
+    # 剔除整列零波动（长期停牌 / 新股未上市）
+    block = block.loc[:, block.std(axis=0) > 1e-9]
+    return block
+
+
+def absorption_ratio(block: pd.DataFrame) -> float:
+    """第一主成分解释方差占比 λ₁ / Σλ。
+
+    对每列做 z-score 标准化（等价于对相关矩阵做 PCA），再用 SVD 求奇异值，
+    λᵢ ∝ sᵢ²，故 AR = s₁² / Σsᵢ²。返回 0~1 的占比。
+    """
+    x = block.to_numpy(dtype=float)
+    x = x - x.mean(axis=0, keepdims=True)
+    std = x.std(axis=0, ddof=0, keepdims=True)
+    std[std < 1e-12] = 1.0
+    x = x / std
+    # 奇异值平方正比于协方差/相关矩阵特征值
+    sv = np.linalg.svd(x, compute_uv=False)
+    eig = sv**2
+    total = eig.sum()
+    if total <= 0:
+        return float("nan")
+    return float(eig[0] / total)
+
+
+def direction_consistency(block: pd.DataFrame) -> float:
+    """齐涨齐跌方向一致率均值 c̄。
+
+    每个交易日 c_t = max(上涨股占比, 下跌股占比)，分母为当日有效成分股数。
+    """
+    up = (block > 0).sum(axis=1)
+    down = (block < 0).sum(axis=1)
+    n = up + down + (block == 0).sum(axis=1)
+    n = n.replace(0, np.nan)
+    c_t = pd.concat([up / n, down / n], axis=1).max(axis=1)
+    return float(c_t.mean())
+
+
+def score_sector(returns: pd.DataFrame) -> dict | None:
+    """对单个板块的成分股收益矩阵计算两版打分。"""
+    block = _clean_block(returns)
+    if block.shape[1] < MIN_MEMBERS or block.shape[0] < MIN_OBS_DAYS:
+        return None
+
+    ar = absorption_ratio(block)
+    cbar = direction_consistency(block)
+    score1 = ar * 100.0
+    score2 = float(np.clip((cbar - DIRECTION_BASELINE) / (1 - DIRECTION_BASELINE), 0, 1) * 100.0)
+    return {
+        "n_valid": block.shape[1],
+        "n_days": block.shape[0],
+        "absorption_ratio": round(ar, 4),
+        "score_absorption": round(score1, 2),
+        "dir_consistency": round(cbar, 4),
+        "score_direction": round(score2, 2),
+        "score_avg": round((score1 + score2) / 2, 2),
+        "_valid_codes": tuple(sorted(block.columns)),  # 用于去重：清洗后真正参与打分的成分集合
+    }
+
+
+def _dedup_by_members(df: pd.DataFrame) -> pd.DataFrame:
+    """按「有效成分集合」去重。
+
+    同花顺行业指数存在层级冗余（如 保险 / 保险Ⅲ / 保险Ⅲ(A股) 经清洗后落到同一批
+    成分股，打分完全相同）。这里把有效成分集合相同的指数合并为一行，代表项取名称最短
+    （最简洁的层级，如"保险"而非"保险Ⅲ(A股)"），并记录合并数量与被合并的别名。
+    """
+    df = df.copy()
+    df["_key"] = df["_valid_codes"].map(lambda t: "|".join(t))
+    df["_namelen"] = df["name"].str.len()
+    out = []
+    for _, g in df.groupby("_key", sort=False):
+        g = g.sort_values(["_namelen", "n_members"], ascending=[True, False])
+        rep = g.iloc[0].to_dict()
+        rep["n_merged"] = len(g)
+        rep["aliases"] = "，".join(n for n in g["name"].tolist() if n != rep["name"])
+        out.append(rep)
+    return pd.DataFrame(out)
+
+
+def analyze(
+    dc, concepts: pd.DataFrame, members: dict[str, list[str]], matrix: pd.DataFrame, dedup: bool = False
+) -> pd.DataFrame:
+    """逐板块打分，返回结果 DataFrame（按综合分降序）。dedup=True 时按有效成分集合去重。"""
+    name_map = dict(zip(concepts["ts_code"], concepts["name"], strict=False))
+    count_map = dict(zip(concepts["ts_code"], concepts.get("count", pd.Series(dtype=float)), strict=False))
+    rows = []
+    for code, cons in tqdm(members.items(), desc="计算板块纯度"):
+        cols = [c for c in cons if c in matrix.columns]
+        if len(cols) < MIN_MEMBERS:
+            continue
+        res = score_sector(matrix[cols])
+        if res is None:
+            continue
+        cnt = count_map.get(code)
+        res.update(
+            {
+                "ts_code": code,
+                "name": name_map.get(code, code),
+                "n_members": int(cnt) if cnt is not None and not pd.isna(cnt) else len(cons),
+            }
+        )
+        rows.append(res)
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+    if dedup:
+        df = _dedup_by_members(df)
+    cols = [
+        "ts_code",
+        "name",
+        "n_members",
+        "n_valid",
+        "n_days",
+        "score_avg",
+        "score_absorption",
+        "absorption_ratio",
+        "score_direction",
+        "dir_consistency",
+    ]
+    if dedup:
+        cols += ["n_merged", "aliases"]
+    df = df[cols].sort_values("score_avg", ascending=False, ignore_index=True)
+    df.insert(0, "rank", range(1, len(df) + 1))
+    return df
+
+
+# ============================================================================
+# HTML 报告
+# ============================================================================
+def build_html_report(df: pd.DataFrame, meta: dict, out_path: Path) -> None:
+    """生成自包含 HTML 报告：散点图 + Top 排行柱状图 + 可排序明细表。"""
+    import plotly.graph_objects as go
+    from plotly.offline import get_plotlyjs
+
+    # 散点：吸收率得分 vs 方向一致性得分
+    scatter = go.Figure()
+    scatter.add_trace(
+        go.Scatter(
+            x=df["score_absorption"],
+            y=df["score_direction"],
+            mode="markers",
+            marker={
+                "size": 7,
+                "color": df["score_avg"],
+                "colorscale": "RdYlGn",
+                "showscale": True,
+                "colorbar": {"title": "综合分"},
+                "line": {"width": 0.5, "color": "#555"},
+            },
+            text=df["name"],
+            customdata=df[["ts_code", "n_valid"]],
+            hovertemplate="<b>%{text}</b><br>吸收率分: %{x}<br>一致性分: %{y}"
+            "<br>代码: %{customdata[0]}<br>有效成分: %{customdata[1]}<extra></extra>",
+        )
+    )
+    scatter.update_layout(
+        title="板块纯度分布：第一主成分解释力 vs 齐涨齐跌一致性",
+        xaxis_title="Absorption 得分",
+        yaxis_title="方向一致性得分",
+        template="plotly_white",
+        height=520,
+    )
+
+    # Top 30 柱状图
+    top = df.head(30).iloc[::-1]
+    bar = go.Figure()
+    bar.add_trace(
+        go.Bar(x=top["score_absorption"], y=top["name"], orientation="h", name="Absorption", marker_color="#2c7fb8")
+    )
+    bar.add_trace(
+        go.Bar(x=top["score_direction"], y=top["name"], orientation="h", name="方向一致性", marker_color="#fdae61")
+    )
+    bar.update_layout(
+        title="纯度 Top 30 板块（按综合分）",
+        barmode="group",
+        template="plotly_white",
+        height=820,
+        legend={"orientation": "h"},
+    )
+
+    scatter_html = scatter.to_html(full_html=False, include_plotlyjs=False)
+    bar_html = bar.to_html(full_html=False, include_plotlyjs=False)
+    table_html = _df_to_sortable_table(df)
+    plotlyjs = get_plotlyjs()
+
+    label = meta.get("type_label", "概念")
+    summary = (
+        f"分析窗口 <b>{meta['start']} ~ {meta['end']}</b>（{meta['n_dates']} 个交易日）｜"
+        f"{label}板块 <b>{meta['n_concepts']}</b> 个，成功打分 <b>{len(df)}</b> 个｜"
+        f"成分股并集 <b>{meta['universe']}</b> 只｜生成时间 {meta['generated_at']}"
+    )
+
+    html = f"""<!DOCTYPE html>
+<html lang="zh-CN"><head><meta charset="utf-8">
+<title>同花顺{label}板块成分股纯度分析</title>
+<script>{plotlyjs}</script>
+<style>
+  body {{ font-family: -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+          margin: 0 auto; max-width: 1180px; padding: 24px; color: #1f2329; }}
+  h1 {{ font-size: 24px; }}
+  .summary {{ background:#f2f6fc; border-left:4px solid #2c7fb8; padding:12px 16px;
+              border-radius:6px; margin:16px 0; line-height:1.8; }}
+  .note {{ color:#646a73; font-size:13px; line-height:1.8; }}
+  table {{ border-collapse: collapse; width: 100%; font-size: 13px; margin-top: 12px; }}
+  th, td {{ border: 1px solid #e5e6eb; padding: 6px 10px; text-align: right; }}
+  th {{ background:#2c7fb8; color:#fff; cursor:pointer; position:sticky; top:0; user-select:none; }}
+  th:hover {{ background:#236299; }}
+  td:nth-child(2), td:nth-child(3) {{ text-align:left; }}
+  tr:nth-child(even) {{ background:#f7f8fa; }}
+  .sec {{ margin-top: 36px; }}
+</style></head>
+<body>
+<h1>📊 同花顺{label}板块 · 成分股纯度分析</h1>
+<div class="summary">{summary}</div>
+<div class="note">
+  <b>score_absorption</b> = 第一主成分解释方差占比 λ₁/Σλ × 100（板块被单一共同因子驱动的程度，越高越纯）；
+  <b>score_direction</b> = 齐涨齐跌方向一致率按 0.55 重标定后 × 100；
+  <b>score_avg</b> = 两者均值。点击表头可排序。
+</div>
+<div class="sec">{scatter_html}</div>
+<div class="sec">{bar_html}</div>
+<div class="sec"><h2>全部板块明细（{len(df)} 个）</h2>{table_html}</div>
+<script>
+  document.querySelectorAll('th').forEach(function(th, idx) {{
+    th.addEventListener('click', function() {{
+      var tbody = th.closest('table').querySelector('tbody');
+      var rows = Array.from(tbody.querySelectorAll('tr'));
+      var asc = th.dataset.asc !== 'true'; th.dataset.asc = asc;
+      rows.sort(function(a, b) {{
+        var x = a.children[idx].innerText, y = b.children[idx].innerText;
+        var nx = parseFloat(x), ny = parseFloat(y);
+        if (!isNaN(nx) && !isNaN(ny)) return asc ? nx - ny : ny - nx;
+        return asc ? x.localeCompare(y, 'zh') : y.localeCompare(x, 'zh');
+      }});
+      rows.forEach(function(r) {{ tbody.appendChild(r); }});
+    }});
+  }});
+</script>
+</body></html>"""
+    out_path.write_text(html, encoding="utf-8")
+    logger.info(f"HTML 报告已生成：{out_path}")
+
+
+def _df_to_sortable_table(df: pd.DataFrame) -> str:
+    """把结果 DataFrame 转成带表头的 HTML 表格（中文列名）。"""
+    headers = {
+        "rank": "排名",
+        "ts_code": "板块代码",
+        "name": "板块名称",
+        "n_members": "成分数",
+        "n_valid": "有效成分",
+        "n_days": "交易日",
+        "score_avg": "综合分",
+        "score_absorption": "Absorption分",
+        "absorption_ratio": "λ₁/Σλ",
+        "score_direction": "一致性分",
+        "dir_consistency": "c̄",
+        "n_merged": "合并数",
+        "aliases": "合并别名",
+    }
+    use = [c for c in headers if c in df.columns]  # 去重列（n_merged/aliases）按需出现
+    show = df[use].rename(columns=headers)
+    return show.to_html(index=False, border=0, escape=False)
+
+
+# ============================================================================
+# 入口
+# ============================================================================
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="同花顺概念板块成分股纯度分析")
+    p.add_argument("--start", default=None, help="起始日期 YYYYMMDD（不填则取最近 --days 个交易日）")
+    p.add_argument("--end", default=None, help="结束日期 YYYYMMDD（默认今天）")
+    p.add_argument("--days", type=int, default=DEFAULT_DAYS, help=f"回看交易日数量，默认 {DEFAULT_DAYS}")
+    p.add_argument(
+        "--index-type",
+        default="N",
+        choices=list(INDEX_TYPE_LABELS),
+        help="同花顺指数类型：N=概念(默认) I=行业 R=地域 S=特色 ST=风格 TH=主题 BB=宽基",
+    )
+    p.add_argument("--limit", type=int, default=None, help="仅处理前 N 个板块（用于快速验证）")
+    p.add_argument("--dedup", action="store_true", help="按有效成分集合去重（同花顺行业指数层级冗余时建议开启）")
+    p.add_argument("--token", default=None, help="Tushare token（默认读 .env / 环境变量）")
+    p.add_argument("--output-dir", default=str(ROOT / "scripts" / "output"), help="输出目录")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    _load_dotenv(ROOT)
+    dc = build_client(args.token)
+
+    out_dir = Path(os.path.expanduser(args.output_dir))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    trade_dates = resolve_trade_dates(dc, args.start, args.end, args.days)
+    if len(trade_dates) < MIN_OBS_DAYS:
+        logger.error(f"交易日数量 {len(trade_dates)} 少于最小观测天数 {MIN_OBS_DAYS}")
+        sys.exit(1)
+    logger.info(f"分析窗口：{trade_dates[0]} ~ {trade_dates[-1]}（{len(trade_dates)} 个交易日）")
+
+    type_label = INDEX_TYPE_LABELS.get(args.index_type, args.index_type)
+    concepts = fetch_concept_list(dc, args.index_type, args.limit)
+    members = fetch_members(dc, concepts["ts_code"].tolist())
+    universe = {c for cons in members.values() for c in cons}
+    logger.info(f"成分股并集：{len(universe)} 只")
+
+    matrix = fetch_return_matrix(dc, trade_dates, universe)
+    if matrix.empty:
+        logger.error("收益矩阵为空，终止")
+        sys.exit(1)
+    logger.info(f"收益矩阵形状：{matrix.shape}")
+
+    result = analyze(dc, concepts, members, matrix, dedup=args.dedup)
+    if result.empty:
+        logger.error("无板块满足打分条件，终止")
+        sys.exit(1)
+
+    stamp = f"{args.index_type}_{trade_dates[0]}_{trade_dates[-1]}" + ("_dedup" if args.dedup else "")
+    csv_path = out_dir / f"sector_purity_{stamp}.csv"
+    html_path = out_dir / f"sector_purity_{stamp}.html"
+    result.to_csv(csv_path, index=False, encoding="utf-8-sig")
+    logger.info(f"明细 CSV 已保存：{csv_path}")
+
+    meta = {
+        "start": trade_dates[0],
+        "end": trade_dates[-1],
+        "n_dates": len(trade_dates),
+        "n_concepts": len(concepts),
+        "universe": len(universe),
+        "index_type": args.index_type,
+        "type_label": type_label,
+        "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
+    }
+    build_html_report(result, meta, html_path)
+
+    print("\n=== 纯度 Top 15 板块 ===")
+    print(result.head(15).to_string(index=False))
+    print(f"\nCSV : {csv_path}\nHTML: {html_path}")
+    (out_dir / f"sector_purity_{stamp}_meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from czsc import Event, Position
+
+
+@pytest.fixture
+def position_file(tmp_path):
+    """构造一个 unique_signals 非空的真实 Position，落盘为 JSON 文件，返回路径。"""
+    oe = Event.load({"operate": "开多", "signals_all": ["30分钟_D1_表里关系V230101_向上_任意_任意_0"]})
+    xe = Event.load({"operate": "平多", "signals_all": ["30分钟_D1_表里关系V230101_向下_任意_任意_0"]})
+    pos = Position(symbol="000001", name="表里多头", opens=[oe], exits=[xe], interval=0, timeout=20, stop_loss=300)
+    p = tmp_path / "pos.json"
+    p.write_text(pos.to_json())
+    return p

--- a/tests/cli/test_acceptance.py
+++ b/tests/cli/test_acceptance.py
@@ -1,0 +1,45 @@
+"""端到端验收：模拟 LLM 用 schema 发现 → 调用核心命令全链路。"""
+
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_schema_then_call_chain(tmp_path, position_file):
+    # 1. schema 自发现
+    schema = json.loads(runner.invoke(app, ["schema", "--json"]).stdout)
+    cmds = {c["command"] for c in schema}
+    assert {"czsc signals list", "czsc analyze", "czsc backtest", "czsc data mock"} <= cmds
+
+    # 2. 造数
+    csv = tmp_path / "k.csv"
+    r = runner.invoke(
+        app,
+        [
+            "data",
+            "mock",
+            "--symbol",
+            "000001",
+            "--freq",
+            "30分钟",
+            "--sdt",
+            "20200101",
+            "--edt",
+            "20240101",
+            "-o",
+            str(csv),
+        ],
+    )
+    assert r.exit_code == 0
+
+    # 3. analyze
+    a = json.loads(runner.invoke(app, ["analyze", str(csv), "--freq", "30分钟", "--json"]).stdout)
+    assert a["fx_list"] and a["bi_list"]
+
+    # 4. backtest
+    b = json.loads(runner.invoke(app, ["backtest", str(position_file), "--bars", str(csv), "--json"]).stdout)
+    assert "年化收益" in b["portfolio"]

--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -1,0 +1,27 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _mock_csv(tmp_path):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / "k.csv"
+    generate_symbol_kines("000001", "30分钟", "20230101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_analyze_json_has_fx_and_bi(tmp_path):
+    p = _mock_csv(tmp_path)
+    r = runner.invoke(app, ["analyze", str(p), "--freq", "30分钟", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert data["symbol"] == "000001"
+    assert len(data["fx_list"]) > 0
+    assert len(data["bi_list"]) > 0
+    assert {"dt", "mark", "fx"} <= set(data["fx_list"][0])
+    assert {"sdt", "edt", "direction", "high", "low"} <= set(data["bi_list"][0])

--- a/tests/cli/test_backtest.py
+++ b/tests/cli/test_backtest.py
@@ -36,4 +36,4 @@ def test_backtest_html_report(tmp_path, position_file):
 def test_backtest_requires_data_source(position_file):
     r = runner.invoke(app, ["backtest", str(position_file), "--json"])
     assert r.exit_code != 0
-    assert json.loads(r.stderr)["error"]["message"]
+    assert "必须提供" in json.loads(r.stderr)["error"]["message"]

--- a/tests/cli/test_backtest.py
+++ b/tests/cli/test_backtest.py
@@ -1,0 +1,39 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path, symbol="000001"):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / f"{symbol}.csv"
+    generate_symbol_kines(symbol, "30分钟", "20200101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_backtest_with_bars_file_json(tmp_path, position_file):
+    bars = _bars_csv(tmp_path)
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(bars), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "symbols" in data and "portfolio" in data
+    assert "000001" in data["symbols"]
+    assert "年化收益" in data["portfolio"]
+
+
+def test_backtest_html_report(tmp_path, position_file):
+    bars = _bars_csv(tmp_path)
+    out = tmp_path / "report.html"
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(bars), "--html", str(out), "--json"])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_backtest_requires_data_source(position_file):
+    r = runner.invoke(app, ["backtest", str(position_file), "--json"])
+    assert r.exit_code != 0
+    assert json.loads(r.stderr)["error"]["message"]

--- a/tests/cli/test_bench.py
+++ b/tests/cli/test_bench.py
@@ -1,0 +1,16 @@
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+@pytest.mark.slow
+def test_bench_json_reports_throughput():
+    r = runner.invoke(app, ["bench", "--years", "1", "--freq", "30分钟", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert data["czsc_construct"]["bars_per_sec"] > 0

--- a/tests/cli/test_cli_skeleton.py
+++ b/tests/cli/test_cli_skeleton.py
@@ -1,0 +1,12 @@
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_app_help_lists_subcommands():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for name in ["signals", "analyze", "backtest", "research", "data", "plot", "bench", "schema"]:
+        assert name in result.output

--- a/tests/cli/test_data.py
+++ b/tests/cli/test_data.py
@@ -1,0 +1,45 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_data_mock_writes_csv(tmp_path):
+    out = tmp_path / "k.csv"
+    r = runner.invoke(
+        app,
+        [
+            "data",
+            "mock",
+            "--symbol",
+            "000001",
+            "--freq",
+            "30分钟",
+            "--sdt",
+            "20240101",
+            "--edt",
+            "20240201",
+            "-o",
+            str(out),
+        ],
+    )
+    assert r.exit_code == 0, r.output
+    assert out.exists()
+    import pandas as pd
+
+    df = pd.read_csv(out)
+    assert {"dt", "symbol", "open", "close", "high", "low", "vol", "amount"} <= set(df.columns)
+
+
+def test_data_quality_json(tmp_path):
+    csv = tmp_path / "k.csv"
+    from czsc.mock import generate_symbol_kines
+
+    generate_symbol_kines("000001", "30分钟", "20240101", "20240201").to_csv(csv, index=False)
+    r = runner.invoke(app, ["data", "quality", str(csv), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "000001" in data

--- a/tests/cli/test_human.py
+++ b/tests/cli/test_human.py
@@ -1,0 +1,64 @@
+"""human 模式（非 --json）渲染路径覆盖：确认退出码 0 且关键文本出现。"""
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path, symbol="000001"):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / f"{symbol}.csv"
+    generate_symbol_kines(symbol, "30分钟", "20200101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_signals_list_human():
+    r = runner.invoke(app, ["signals", "list"])
+    assert r.exit_code == 0, r.output
+    assert "共" in r.output and "个信号" in r.output
+
+
+def test_signals_doc_human():
+    listing = runner.invoke(app, ["signals", "list", "--json"])
+    import json
+
+    name = json.loads(listing.stdout)[0]["name"]
+    r = runner.invoke(app, ["signals", "doc", name])
+    assert r.exit_code == 0, r.output
+    assert "参数模板" in r.output
+
+
+def test_analyze_human(tmp_path):
+    p = _bars_csv(tmp_path)
+    r = runner.invoke(app, ["analyze", str(p), "--freq", "30分钟"])
+    assert r.exit_code == 0, r.output
+    assert "分型=" in r.output and "笔=" in r.output
+
+
+def test_data_quality_human(tmp_path):
+    p = _bars_csv(tmp_path)
+    r = runner.invoke(app, ["data", "quality", str(p)])
+    assert r.exit_code == 0, r.output
+    assert "[000001]" in r.output
+
+
+def test_backtest_human(tmp_path, position_file):
+    p = _bars_csv(tmp_path)
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(p)])
+    assert r.exit_code == 0, r.output
+    assert "组合绩效" in r.output and "年化收益" in r.output
+
+
+def test_schema_human():
+    r = runner.invoke(app, ["schema"])
+    assert r.exit_code == 0, r.output
+    assert "czsc backtest" in r.output
+
+
+def test_bench_human():
+    r = runner.invoke(app, ["bench", "--years", "1", "--freq", "30分钟"])
+    assert r.exit_code == 0, r.output
+    assert "bars/s" in r.output

--- a/tests/cli/test_io.py
+++ b/tests/cli/test_io.py
@@ -1,0 +1,42 @@
+import json
+
+import pytest
+import typer
+
+from czsc.cli import _io
+from czsc.mock import generate_symbol_kines
+
+
+def test_load_bars_df_csv(tmp_path):
+    df = generate_symbol_kines("000001", "30分钟", "20240101", "20240105")
+    p = tmp_path / "k.csv"
+    df.to_csv(p, index=False)
+    out = _io.load_bars_df(str(p))
+    for col in ["dt", "symbol", "open", "close", "high", "low", "vol", "amount"]:
+        assert col in out.columns
+
+
+def test_load_bars_df_missing_columns(tmp_path):
+    p = tmp_path / "bad.csv"
+    p.write_text("a,b\n1,2\n")
+    with pytest.raises(ValueError, match="缺少必需列"):
+        _io.load_bars_df(str(p))
+
+
+def test_emit_json(capsys):
+    _io.emit({"k": 1}, json_out=True, human=lambda d: None)
+    out = capsys.readouterr().out
+    assert json.loads(out) == {"k": 1}
+
+
+def test_fail_json_raises_exit(capsys):
+    with pytest.raises(typer.Exit):
+        _io.fail("boom", json_out=True, err_type="ValueError")
+    err = capsys.readouterr().err
+    assert json.loads(err)["error"]["message"] == "boom"
+
+
+def test_freq_to_cn():
+    assert _io.freq_to_cn("F30") == "30分钟"
+    assert _io.freq_to_cn("30分钟") == "30分钟"
+    assert _io.freq_to_cn("D") == "日线"

--- a/tests/cli/test_plot.py
+++ b/tests/cli/test_plot.py
@@ -1,0 +1,34 @@
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / "k.csv"
+    generate_symbol_kines("000001", "30分钟", "20230101", "20240101").to_csv(p, index=False)
+    return p
+
+
+def test_plot_czsc_writes_html(tmp_path):
+    p = _bars_csv(tmp_path)
+    out = tmp_path / "c.html"
+    r = runner.invoke(app, ["plot", "czsc", str(p), "--freq", "30分钟", "-o", str(out)])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_plot_signals_writes_html(tmp_path):
+    p = _bars_csv(tmp_path)
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('[{"name": "30分钟_D1_表里关系V230101_向上_任意_任意_0"}]')
+    out = tmp_path / "s.html"
+    r = runner.invoke(
+        app,
+        ["plot", "signals", str(p), "--signals-config", str(cfg), "--freq", "30分钟", "-o", str(out)],
+    )
+    assert r.exit_code == 0, r.output
+    assert out.exists() and out.stat().st_size > 0

--- a/tests/cli/test_research.py
+++ b/tests/cli/test_research.py
@@ -1,0 +1,15 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_research_config_derives():
+    r = runner.invoke(app, ["research", "config", "30分钟_D1_表里关系V230101_向上_任意_任意_0", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert "signals_config" in data and "freqs" in data
+    assert data["freqs"] == ["30分钟"]

--- a/tests/cli/test_review_fixes.py
+++ b/tests/cli/test_review_fixes.py
@@ -1,0 +1,88 @@
+"""回归测试：覆盖 /code-review 发现并修复的缺陷。"""
+
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import _io, app
+
+runner = CliRunner()
+
+
+def _bars_csv(tmp_path, symbol="000001", sdt="20200101", edt="20240101"):
+    from czsc.mock import generate_symbol_kines
+
+    p = tmp_path / f"{symbol}.csv"
+    generate_symbol_kines(symbol, "30分钟", sdt, edt).to_csv(p, index=False)
+    return p
+
+
+def test_load_bars_df_coerces_numeric_to_float(tmp_path):
+    """mock CSV 的 vol 是 int64，load_bars_df 必须转 float，否则 research 透传 Rust 会崩。"""
+    p = _bars_csv(tmp_path, sdt="20240101", edt="20240301")
+    df = _io.load_bars_df(str(p))
+    for col in ["open", "close", "high", "low", "vol", "amount"]:
+        assert str(df[col].dtype) == "float64", col
+
+
+def test_research_run_with_mock_csv(tmp_path, position_file):
+    """data mock → research run 全链路：曾因 int64 vol 崩 Polars。"""
+    from czsc import CzscStrategyBase, Position
+
+    bars_csv = _bars_csv(tmp_path)
+    pos = Position.from_json(position_file.read_text())
+
+    class _S(CzscStrategyBase):
+        @property
+        def positions(self):
+            return [pos]
+
+    strat = _S(symbol="000001")
+    strat_json = tmp_path / "strat.json"
+    strat_json.write_text(
+        json.dumps(
+            {
+                "symbol": "000001",
+                "base_freq": strat.base_freq,
+                "freqs": strat.freqs,
+                "positions": [pos.dump()],
+                "signals_config": strat.signals_config,
+            },
+            ensure_ascii=False,
+        )
+    )
+    r = runner.invoke(app, ["research", "run", str(bars_csv), str(strat_json), "--json"])
+    assert r.exit_code == 0, r.output
+    assert "meta" in json.loads(r.stdout)
+
+
+def test_data_quality_json_clean_on_bad_data(tmp_path):
+    """含异常数据时 stdout 仍是纯 JSON（check_kline_quality 的 print 副作用被吞掉）。"""
+
+    from czsc.mock import generate_symbol_kines
+
+    df = generate_symbol_kines("000001", "30分钟", "20240101", "20240301")
+    df.loc[df.index[0], "vol"] = -5  # 制造负成交量
+    csv = tmp_path / "bad.csv"
+    df.to_csv(csv, index=False)
+    r = runner.invoke(app, ["data", "quality", str(csv), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)  # 不应抛 JSONDecodeError
+    assert data["000001"]["volume_amount"]["n_bad_rows"] >= 1
+
+
+def test_backtest_multi_symbol_labels_distinct(tmp_path, position_file):
+    """多 symbol：每个 symbol 的标签用回测标的，而非 position 自带 symbol。"""
+    import pandas as pd
+
+    from czsc.mock import generate_symbol_kines
+
+    a = generate_symbol_kines("AAAAAA", "30分钟", "20210101", "20240101")
+    b = generate_symbol_kines("BBBBBB", "30分钟", "20210101", "20240101")
+    csv = tmp_path / "two.csv"
+    pd.concat([a, b], ignore_index=True).to_csv(csv, index=False)
+    r = runner.invoke(app, ["backtest", str(position_file), "--bars", str(csv), "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert set(data["symbols"]) == {"AAAAAA", "BBBBBB"}
+    assert "品种数量" in data["portfolio"] or "年化收益" in data["portfolio"]

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -1,0 +1,18 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_schema_json_lists_commands():
+    r = runner.invoke(app, ["schema", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    cmds = {c["command"] for c in data}
+    assert "czsc signals list" in cmds
+    assert "czsc backtest" in cmds
+    entry = next(c for c in data if c["command"] == "czsc signals list")
+    assert entry["params"]

--- a/tests/cli/test_signals.py
+++ b/tests/cli/test_signals.py
@@ -28,4 +28,4 @@ def test_signals_doc_known_name():
 def test_signals_doc_unknown_name_fails():
     r = runner.invoke(app, ["signals", "doc", "不存在的信号xyz", "--json"])
     assert r.exit_code != 0
-    assert json.loads(r.stderr)["error"]["message"]
+    assert "未找到信号" in json.loads(r.stderr)["error"]["message"]

--- a/tests/cli/test_signals.py
+++ b/tests/cli/test_signals.py
@@ -1,0 +1,31 @@
+import json
+
+from typer.testing import CliRunner
+
+from czsc.cli import app
+
+runner = CliRunner()
+
+
+def test_signals_list_json_has_entries():
+    r = runner.invoke(app, ["signals", "list", "--json"])
+    assert r.exit_code == 0, r.output
+    data = json.loads(r.stdout)
+    assert isinstance(data, list) and len(data) > 100
+    assert {"name", "param_template", "category", "namespace"} <= set(data[0])
+
+
+def test_signals_doc_known_name():
+    listing = json.loads(runner.invoke(app, ["signals", "list", "--json"]).stdout)
+    name = listing[0]["name"]
+    r = runner.invoke(app, ["signals", "doc", name, "--json"])
+    assert r.exit_code == 0, r.output
+    doc = json.loads(r.stdout)
+    assert doc["name"] == name
+    assert "param_template" in doc
+
+
+def test_signals_doc_unknown_name_fails():
+    r = runner.invoke(app, ["signals", "doc", "不存在的信号xyz", "--json"])
+    assert r.exit_code != 0
+    assert json.loads(r.stderr)["error"]["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.python.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.10.0"
 source = { registry = "https://pypi.python.org/simple" }
@@ -531,6 +540,7 @@ dependencies = [
     { name = "statsmodels" },
     { name = "tenacity" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "wbt" },
 ]
 
@@ -597,6 +607,7 @@ requires-dist = [
     { name = "tenacity" },
     { name = "tqdm", specifier = ">=4.66.4" },
     { name = "twine", marker = "extra == 'release'" },
+    { name = "typer", specifier = ">=0.12.0" },
     { name = "wbt", specifier = ">=0.2.1" },
 ]
 provides-extras = ["all", "dev", "release", "test"]
@@ -2814,6 +2825,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.python.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "simplejson"
 version = "3.20.1"
 source = { registry = "https://pypi.python.org/simple" }
@@ -3124,6 +3144,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.5"
+source = { registry = "https://pypi.python.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/1a/2cf40b65b1d9c254fe5814bb0519f9b8f2ac38059df0810f9b866300c04a/typer-0.26.5.tar.gz", hash = "sha256:9b9b39e35c3afc9e1e51a06f21155246e457c0911279b09b35d8210ca74b935c", size = 201494, upload-time = "2026-06-01T14:42:49.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/d6/baac76fc04a6532883de3d8722c7f921dae94d10965e7ffba9e38e42a251/typer-0.26.5-py3-none-any.whl", hash = "sha256:4bfd901d564e41608920134aa5d4481200f4ba76d98e982d9f9d32dcb7b84da0", size = 122451, upload-time = "2026-06-01T14:42:51.021Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景
为 czsc 新增统一 CLI（入口 `czsc`），把信号目录、缠论分析、策略回测、研究、可视化、性能基准暴露成子命令，方便大模型以 function-calling 调用，同时兼顾人类终端使用。

设计文档：https://s0cqcxuy3p.feishu.cn/wiki/IoGRwkHxwiiHP8kOWwJc1s85nSb

## 改动
- 新建 `czsc/cli/` 子包，注册 `[project.scripts] czsc = "czsc.cli:app"`，typer 入核心依赖
- `_io.py` 共享层：行情加载（symbol 按 str、OHLCV 转 float）/ JSON 渲染 / 错误边界 / 连接器懒加载分发
- **13 条命令**：`signals list/doc`、`analyze`、`backtest`、`research run/replay/config`、`data mock/quality`、`plot czsc/signals`、`bench`、`schema`
- `backtest`：Position JSON + 数据源（`local/tushare/ccxt` 或 `--bars`，多 symbol）→ `CzscStrategyBase.backtest` + `WeightBacktest` 绩效 + 可选 wbt HTML 报告（覆盖案例 1）
- 人机两用：默认人类可读，`--json` 时 stdout 纯 JSON、错误走 stderr + 非零退出码
- `schema` 元命令供 LLM 自发现

## 设计要点
- CLI 是纯调用壳，只做「解析参数 → 调 czsc.* 公共 API → 渲染」，不写业务/算法逻辑（符合开发宪法第一条）
- 所有数据来源走运行时 `czsc._native`，pip 用户可用，不依赖扫描 .rs 源文件
- `freq_to_cn` 直接走 `czsc.Freq(freq).value`，与 Rust 端频率定义单一来源

## 测试与验收
- CLI 测试 32 passed（含 slow + review 回归），typer CliRunner 覆盖 json/human/错误三条路径
- 全仓回归 493 passed / 6 skipped（无回归）
- 本地复现 CI 全部门禁均过：`ruff format --check`、`ruff check`、`pytest tests/`、`basedpyright`（cli 类型错误清零）
- 经 1 轮 code-reviewer + 1 轮 /code-review，修复 6 个 confirmed bug（int64 vol 崩 Polars、quality stdout 污染 JSON、多 symbol 标签串味、空成交守卫等）

## 已知后续增量（非本 PR 阻塞）
- `plot trader`（案例 2 多周期联立）
- 多 symbol 组合权重资金归一化
