### PR TITLE
SKZ-19: fix CZSC_MIN_BI_LEN Rust analyzer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CZSC_MIN_BI_LEN` 现在真正作用于 Rust 端成笔逻辑**（[waditu/czsc#328](https://github.com/waditu/czsc/issues/328)）：此前 `crates/czsc-core/src/analyze/utils.rs` 的 `check_bi` 硬编码 `let min_bi_len = 6;`，且 `CZSC` 构造函数签名只有 `(bars_raw, max_bi_num)`，导致 `CZSC_MIN_BI_LEN` 只影响 `czsc.envs.get_min_bi_len()` 的返回值、对 `bi_list` / `finished_bis` 毫无作用。修复：
+  - `CZSC` 增加 `min_bi_len` 字段；`check_bi(bars, min_bi_len)` 改为接收阈值参数，移除硬编码。
+  - PyO3 构造函数 `CZSC(bars_raw, max_bi_num=0, min_bi_len=0)` / `from_dataframe(...)` 新增 `min_bi_len` 形参；显式参数 >0 时优先，否则读 `CZSC_MIN_BI_LEN`（大小写不敏感），再否则默认 6（与 `czsc.envs` 约定一致）。`max_bi_num` 同理改为 env-aware（默认 0 → 读 `CZSC_MAX_BI_NUM` → 50）。
+  - Rust 构造入口统一为 `CZSC::new(bars, max_bi_num, min_bi_len)`；`CzscSignals` 内部重建 `kas` 时也会读取同一套环境变量。
+  - 新增 `CZSC.min_bi_len` getter；pickle (`__reduce__`) 现在保留 `min_bi_len`。
+  - 回归测试 `min_bi_len_affects_bi_count` 锁定"更大阈值产出更少/更长的笔"。
+
 ### Notes
 
 - **1.0.0-rc.8 在纯 Rust 下游不可用（PyPI 用户不受影响）**：发布后验证发现 cargo 用户 `cargo add czsc@=1.0.0-rc.8` 无法编译。两个根因：

--- a/crates/czsc-core/README.md
+++ b/crates/czsc-core/README.md
@@ -22,7 +22,7 @@ use czsc_core::objects::{RawBar, Freq};
 use czsc_core::analyze::CZSC;
 
 let bars: Vec<RawBar> = /* ... */;
-let czsc = CZSC::new(bars, 50);
+let czsc = CZSC::new(bars, 50, 6);
 println!("最新一笔方向: {:?}", czsc.bi_list.last().map(|b| b.direction));
 ```
 

--- a/crates/czsc-core/benches/czsc_analyze_bench.rs
+++ b/crates/czsc-core/benches/czsc_analyze_bench.rs
@@ -66,7 +66,7 @@ fn bench_czsc_analyze(c: &mut Criterion) {
         b.iter_batched(
             || bars.clone(),
             |input| {
-                let c = CZSC::new(black_box(input), 50);
+                let c = CZSC::new(black_box(input), 50, 6);
                 black_box(c)
             },
             BatchSize::LargeInput,

--- a/crates/czsc-core/src/analyze/mod.rs
+++ b/crates/czsc-core/src/analyze/mod.rs
@@ -43,6 +43,8 @@ pub struct CZSC {
     // verbose: bool,
     /// 最大允许保留的笔数量
     pub max_bi_num: usize,
+    /// 笔的最小长度（去包含后的 K 线根数；默认 6，可由 CZSC_MIN_BI_LEN 覆盖）
+    pub min_bi_len: usize,
     /// 原始K线序列
     pub bars_raw: Vec<RawBar>,
     pub bars_ubi: Vec<NewBar>,
@@ -55,6 +57,36 @@ pub struct CZSC {
     #[serde(skip)]
     #[builder(default = "Arc::new(RwLock::new(None))")]
     pub cache: Arc<RwLock<Option<Py<PyDict>>>>,
+}
+
+/// 解析"显式参数优先、否则环境变量、否则默认"的 usize 配置。
+/// 显式参数 > 0 时直接采用；否则依次读 UPPER / lower 环境变量，
+/// 解析失败或缺失时回落到 `default`。与 `czsc.envs` 大小写约定一致（spec §3.4）。
+fn resolve_env_usize(explicit: usize, upper: &str, lower: &str, default: usize) -> usize {
+    if explicit > 0 {
+        return explicit;
+    }
+    if let Ok(v) = std::env::var(upper) {
+        if let Ok(n) = v.trim().parse::<f64>() {
+            return n as usize;
+        }
+    }
+    if let Ok(v) = std::env::var(lower) {
+        if let Ok(n) = v.trim().parse::<f64>() {
+            return n as usize;
+        }
+    }
+    default
+}
+
+/// 笔最小长度：显式参数 (>0) 优先，否则读 `CZSC_MIN_BI_LEN`（大小写不敏感），再否则 6。
+pub fn resolve_min_bi_len(explicit: usize) -> usize {
+    resolve_env_usize(explicit, "CZSC_MIN_BI_LEN", "czsc_min_bi_len", 6)
+}
+
+/// 最大笔数：显式参数 (>0) 优先，否则读 `CZSC_MAX_BI_NUM`，再否则 50。
+pub fn resolve_max_bi_num(explicit: usize) -> usize {
+    resolve_env_usize(explicit, "CZSC_MAX_BI_NUM", "czsc_max_bi_num", 50)
 }
 
 impl CZSC {
@@ -90,11 +122,12 @@ impl CZSC {
         }
     }
 
-    pub fn new(bars_raw: Vec<RawBar>, max_bi_num: usize) -> Self {
+    pub fn new(bars_raw: Vec<RawBar>, max_bi_num: usize, min_bi_len: usize) -> Self {
         // todo check length of bars_raw
 
         let mut c = Self {
             max_bi_num,
+            min_bi_len,
             bars_raw: Vec::with_capacity(bars_raw.len()), // 预分配容量
             bars_ubi: Vec::with_capacity(bars_raw.len() / 2), // 预估容量
             bi_list: Vec::with_capacity(max_bi_num.min(bars_raw.len() / 10)), // 预估笔数量
@@ -221,7 +254,7 @@ impl CZSC {
                 .filter(|x| x.dt >= fx_a.elements[0].dt)
                 .collect::<Vec<_>>();
 
-            let (bi, bars_ubi_) = check_bi(&bars_ubi);
+            let (bi, bars_ubi_) = check_bi(&bars_ubi, self.min_bi_len);
             if let Some(bi) = bi {
                 self.bi_list.push(bi);
             }
@@ -237,7 +270,7 @@ impl CZSC {
         //     self.bars_ubi.last().unwrap().dt,
         //     self.bars_ubi.len()
         // );
-        let (bi, bars_ubi_) = check_bi(&self.bars_ubi);
+        let (bi, bars_ubi_) = check_bi(&self.bars_ubi, self.min_bi_len);
         if let Some(bi) = bi {
             self.bi_list.push(bi);
         }
@@ -343,9 +376,13 @@ impl CZSC {
 #[cfg_attr(feature = "python", pymethods)]
 impl CZSC {
     #[new]
-    #[pyo3(signature = (bars_raw, max_bi_num=50))]
-    pub fn new_py(bars_raw: Vec<RawBar>, max_bi_num: usize) -> PyResult<Self> {
-        Ok(CZSC::new(bars_raw, max_bi_num))
+    #[pyo3(signature = (bars_raw, max_bi_num=0, min_bi_len=0))]
+    pub fn new_py(bars_raw: Vec<RawBar>, max_bi_num: usize, min_bi_len: usize) -> PyResult<Self> {
+        Ok(CZSC::new(
+            bars_raw,
+            resolve_max_bi_num(max_bi_num),
+            resolve_min_bi_len(min_bi_len),
+        ))
     }
 
     /// 直接从Arrow格式的DataFrame创建CZSC对象，避免中间转换
@@ -356,11 +393,12 @@ impl CZSC {
     /// :param max_bi_num: 最大笔数量限制
     /// :return: CZSC对象
     #[staticmethod]
-    #[pyo3(signature = (df_bytes, freq, max_bi_num=50))]
+    #[pyo3(signature = (df_bytes, freq, max_bi_num=0, min_bi_len=0))]
     pub fn from_dataframe(
         df_bytes: pyo3::Bound<'_, pyo3::types::PyBytes>,
         freq: Freq,
         max_bi_num: usize,
+        min_bi_len: usize,
     ) -> PyResult<Self> {
         // 直接从Arrow字节数据创建DataFrame
         let bytes_data = df_bytes.as_bytes();
@@ -399,7 +437,11 @@ impl CZSC {
         })?;
 
         // 批量创建CZSC对象
-        Ok(CZSC::new(bars, max_bi_num))
+        Ok(CZSC::new(
+            bars,
+            resolve_max_bi_num(max_bi_num),
+            resolve_min_bi_len(min_bi_len),
+        ))
     }
 
     #[getter]
@@ -415,6 +457,11 @@ impl CZSC {
     #[getter]
     fn max_bi_num(&self) -> usize {
         self.max_bi_num
+    }
+
+    #[getter]
+    fn min_bi_len(&self) -> usize {
+        self.min_bi_len
     }
 
     #[getter]
@@ -673,8 +720,8 @@ impl CZSC {
     /// `restored.__getstate__() == obj.__getstate__()` 断言依赖这一点）。
     fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
         use pyo3::IntoPyObject;
-        let trimmed = CZSC::new(self.bars_raw.clone(), self.max_bi_num);
-        let args = (trimmed.bars_raw, self.max_bi_num).into_pyobject(py)?;
+        let trimmed = CZSC::new(self.bars_raw.clone(), self.max_bi_num, self.min_bi_len);
+        let args = (trimmed.bars_raw, self.max_bi_num, self.min_bi_len).into_pyobject(py)?;
         let constructor = py.get_type::<Self>();
         let result = (constructor, args).into_pyobject(py)?;
         Ok(result.into())
@@ -803,7 +850,7 @@ dt,symbol,open,close,high,low,vol,amount
     #[test]
     fn test_czsc_bi_list() {
         let bars = get_bars();
-        let c = CZSC::new(bars, 50);
+        let c = CZSC::new(bars, 50, 6);
 
         let expected = [
             (
@@ -884,7 +931,7 @@ dt,symbol,open,close,high,low,vol,amount
     #[test]
     fn test_czsc_fx_list() {
         let bars = get_bars();
-        let c = CZSC::new(bars, 50);
+        let c = CZSC::new(bars, 50, 6);
 
         let expected = [
             ("2025-01-15 00:00:00", 50.73),

--- a/crates/czsc-core/src/analyze/utils.rs
+++ b/crates/czsc-core/src/analyze/utils.rs
@@ -195,7 +195,7 @@ pub fn check_fx(k1: &NewBar, k2: &NewBar, k3: &NewBar) -> Option<FX> {
 ///
 ///    :param bars: 无包含关系K线列表
 ///    :return:
-pub fn check_bi<B>(bars: &[B]) -> (Option<BI>, &[B])
+pub fn check_bi<B>(bars: &[B], min_bi_len: usize) -> (Option<BI>, &[B])
 where
     B: AsRef<NewBar>,
 {
@@ -268,8 +268,6 @@ where
     let ab_include = (fx_a.high > fx_b.high && fx_a.low < fx_b.low)
         || (fx_a.high < fx_b.high && fx_a.low > fx_b.low);
 
-    // todo
-    let min_bi_len = 6;
     // 检查成笔条件
     if !ab_include && bars_a.len() >= min_bi_len {
         let fxs_filtered: Vec<_> = fxs

--- a/crates/czsc-core/src/python/mod.rs
+++ b/crates/czsc-core/src/python/mod.rs
@@ -43,8 +43,14 @@ fn check_fxs_py(bars: Vec<NewBar>) -> Vec<FX> {
 /// 丢弃未使用的剩余切片；Python 调用方只消费可选的 BI 值。
 #[pyfunction]
 #[pyo3(name = "check_bi")]
-fn check_bi_py(bars: Vec<NewBar>) -> Option<BI> {
-    let (bi, _) = analyze_utils::check_bi(&bars);
+#[pyo3(signature = (bars, min_bi_len=0))]
+fn check_bi_py(bars: Vec<NewBar>, min_bi_len: usize) -> Option<BI> {
+    let n = if min_bi_len > 0 {
+        min_bi_len
+    } else {
+        crate::analyze::resolve_min_bi_len(min_bi_len)
+    };
+    let (bi, _) = analyze_utils::check_bi(&bars, n);
     bi
 }
 

--- a/crates/czsc-core/tests/test_analyze_utils.rs
+++ b/crates/czsc-core/tests/test_analyze_utils.rs
@@ -80,7 +80,7 @@ fn check_bi_returns_none_for_monotone_sequence() {
     let bars: Vec<NewBar> = (0..6)
         .map(|i| nb(i + 1, 10.0 + i as f64, 9.0 + i as f64))
         .collect();
-    let (bi, remainder) = check_bi(&bars);
+    let (bi, remainder) = check_bi(&bars, 6);
     assert!(bi.is_none(), "单调递增序列不应识别出笔");
     assert!(
         remainder.len() <= bars.len(),

--- a/crates/czsc-core/tests/test_czsc_analyzer.rs
+++ b/crates/czsc-core/tests/test_czsc_analyzer.rs
@@ -46,7 +46,7 @@ fn synthetic_zigzag(n: usize) -> Vec<RawBar> {
 #[test]
 fn new_populates_symbol_and_freq() {
     let bars = synthetic_zigzag(50);
-    let c = CZSC::new(bars, 50);
+    let c = CZSC::new(bars, 50, 6);
     assert_eq!(&*c.symbol, "000001");
     assert_eq!(c.freq, Freq::F30);
     assert_eq!(c.max_bi_num, 50);
@@ -55,7 +55,7 @@ fn new_populates_symbol_and_freq() {
 #[test]
 fn new_consumes_all_bars_and_builds_ubi() {
     let bars = synthetic_zigzag(40);
-    let c = CZSC::new(bars, 50);
+    let c = CZSC::new(bars, 50, 6);
     // bars_ubi 是合并后 bar（NewBar）序列；对于 40 根原始 zigzag
     // bar，我们期望合并后的序列非空
     assert!(!c.bars_ubi.is_empty(), "bars_ubi should not be empty");
@@ -64,7 +64,7 @@ fn new_consumes_all_bars_and_builds_ubi() {
 #[test]
 fn fx_and_bi_lists_are_consistent_with_zigzag() {
     let bars = synthetic_zigzag(60);
-    let c = CZSC::new(bars, 50);
+    let c = CZSC::new(bars, 50, 6);
     let fxs = c.get_fx_list();
     // 60 根 zigzag bar 的正弦波形必须产出至少 2 个分型（顶底交替）
     assert!(
@@ -85,7 +85,7 @@ fn fx_and_bi_lists_are_consistent_with_zigzag() {
 #[test]
 fn update_bar_appends_incrementally() {
     let bars = synthetic_zigzag(30);
-    let mut c = CZSC::new(bars, 50);
+    let mut c = CZSC::new(bars, 50, 6);
     let extra = rb(1_700_000_000 + 30 * 1800, 102.0, 103.0, 104.0, 101.0);
     c.update_bar(extra);
     assert_eq!(c.freq, Freq::F30);
@@ -100,8 +100,39 @@ fn update_bar_appends_incrementally() {
 #[test]
 fn analyzer_clones_independently() {
     let bars = synthetic_zigzag(20);
-    let c = CZSC::new(bars, 50);
+    let c = CZSC::new(bars, 50, 6);
     let d = c.clone();
     assert_eq!(d.bi_list.len(), c.bi_list.len());
     assert_eq!(&*d.symbol, &*c.symbol);
+}
+
+/// min_bi_len 必须真正作用于成笔逻辑：更大的阈值会过滤掉更短的笔，
+/// 因此 bi_list 数量应单调不增。这是 issue #328 的回归保护——
+/// 之前该值在 check_bi 里被硬编码为 6，外部传入完全失效。
+#[test]
+fn min_bi_len_affects_bi_count() {
+    let bars = synthetic_zigzag(60);
+    let small = CZSC::new(bars.clone(), 50, 6);
+    let large = CZSC::new(bars, 50, 11);
+    assert!(
+        large.bi_list.len() <= small.bi_list.len(),
+        "min_bi_len=11 不应比 min_bi_len=6 产出更多笔：{} > {}",
+        large.bi_list.len(),
+        small.bi_list.len()
+    );
+    // 所有成笔长度必须 >= 其 min_bi_len 阈值
+    for bi in &small.bi_list {
+        assert!(
+            bi.bars.len() >= 6,
+            "短阈值下出现 <6 的笔：{}",
+            bi.bars.len()
+        );
+    }
+    for bi in &large.bi_list {
+        assert!(
+            bi.bars.len() >= 11,
+            "长阈值下出现 <11 的笔：{}",
+            bi.bars.len()
+        );
+    }
 }

--- a/crates/czsc-signals/benches/signals_bench.rs
+++ b/crates/czsc-signals/benches/signals_bench.rs
@@ -74,7 +74,7 @@ fn dispatch_all_signals(czsc: &CZSC) -> usize {
 fn bench_signals_dispatch(c: &mut Criterion) {
     // ① 单根代表 K 线下分派全部信号——把 100 根 bar 的 CZSC 视为典型回放截面
     let small_bars = generate_bars(100);
-    let small_czsc = CZSC::new(small_bars, 50);
+    let small_czsc = CZSC::new(small_bars, 50, 6);
     let signals_count = SIGNAL_REGISTRY.len();
 
     let mut group = c.benchmark_group("signals_dispatch");
@@ -92,7 +92,7 @@ fn bench_signals_dispatch(c: &mut Criterion) {
 
     // ② 1 万根 K 线场景——目标整体 ≤ 80 ms
     let large_bars = generate_bars(10_000);
-    let large_czsc = CZSC::new(large_bars, 50);
+    let large_czsc = CZSC::new(large_bars, 50, 6);
     group.bench_function(
         format!("dispatch_all({signals_count} signals, bars=10000)"),
         |b| {

--- a/crates/czsc-trader/src/czsc_signals.rs
+++ b/crates/czsc-trader/src/czsc_signals.rs
@@ -1,7 +1,7 @@
 use crate::engine_v2::catalog::SignalCategory;
 use crate::engine_v2::compiler::CompiledSignalPlanV2;
 use crate::sig_parse::SignalConfig;
-use czsc_core::analyze::CZSC;
+use czsc_core::analyze::{CZSC, resolve_max_bi_num, resolve_min_bi_len};
 use czsc_core::objects::bar::RawBar;
 use czsc_core::objects::signal::Signal;
 use czsc_signals::registry;
@@ -99,13 +99,17 @@ pub struct CzscSignals {
 }
 
 impl CzscSignals {
+    fn new_czsc_from_bars(bars: Vec<RawBar>) -> CZSC {
+        CZSC::new(bars, resolve_max_bi_num(0), resolve_min_bi_len(0))
+    }
+
     pub fn new(symbol: String, bg: BarGenerator) -> Self {
         let mut kas = BTreeMap::new();
         for (freq, bars_lock) in &bg.freq_bars {
             let bars = bars_lock.read();
             if !bars.is_empty() {
                 let bars_vec: Vec<RawBar> = bars.iter().cloned().collect();
-                kas.insert(freq.to_string(), CZSC::new(bars_vec, 50));
+                kas.insert(freq.to_string(), Self::new_czsc_from_bars(bars_vec));
             }
         }
 
@@ -358,7 +362,8 @@ impl CzscSignals {
                 continue;
             }
             let bars_vec: Vec<RawBar> = bars.iter().cloned().collect();
-            self.kas.insert(freq.to_string(), CZSC::new(bars_vec, 50));
+            self.kas
+                .insert(freq.to_string(), Self::new_czsc_from_bars(bars_vec));
         }
     }
 
@@ -397,7 +402,7 @@ impl CzscSignals {
 
             if !self.kas.contains_key(&freq_str) {
                 let bars_vec: Vec<RawBar> = bars.iter().cloned().collect();
-                let czsc = CZSC::new(bars_vec, 50);
+                let czsc = Self::new_czsc_from_bars(bars_vec);
                 self.kas.insert(freq_str.clone(), czsc);
                 changed_freqs.insert(freq_str);
             } else if is_changed {

--- a/czsc/_native/__init__.pyi
+++ b/czsc/_native/__init__.pyi
@@ -218,6 +218,8 @@ class CZSC:
     @property
     def max_bi_num(self) -> builtins.int: ...
     @property
+    def min_bi_len(self) -> builtins.int: ...
+    @property
     def bi_list(self) -> builtins.list[BI]: ...
     @property
     def bars_raw(self) -> builtins.list[RawBar]:
@@ -276,9 +278,9 @@ class CZSC:
         最后一笔延伸情况（与 czsc 库兼容）
         判断最后一笔是否在延伸中，True 表示延伸中
         """
-    def __new__(cls, bars_raw: typing.Sequence[RawBar], max_bi_num: builtins.int = 50) -> CZSC: ...
+    def __new__(cls, bars_raw: typing.Sequence[RawBar], max_bi_num: builtins.int = 0, min_bi_len: builtins.int = 0) -> CZSC: ...
     @staticmethod
-    def from_dataframe(df_bytes: bytes, freq: Freq, max_bi_num: builtins.int = 50) -> CZSC:
+    def from_dataframe(df_bytes: bytes, freq: Freq, max_bi_num: builtins.int = 0, min_bi_len: builtins.int = 0) -> CZSC:
         r"""
         直接从Arrow格式的DataFrame创建CZSC对象，避免中间转换
         这是高性能的批量创建接口，适用于大量数据的初始化


### PR DESCRIPTION
## Summary

- Pass `min_bi_len` into Rust-side `check_bi` instead of using the hardcoded `6`.
- Add env-aware `min_bi_len` / `max_bi_num` resolution for PyO3 `CZSC(...)`, `from_dataframe(...)`, and `check_bi(...)`.
- Preserve `min_bi_len` through pickle and expose `CZSC.min_bi_len`.
- Make `CzscSignals` rebuild internal `kas` with the same env-aware analyzer settings.
- Add regression coverage for stricter `min_bi_len` producing no shorter BIs.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p czsc-core`
- `cargo test -p czsc-trader --lib`

Fixes #328
Closes SKZ-19
