### PR TITLE
SKZ-24: fix clippy lint failure

### DIFF
--- a/crates/czsc-core/src/analyze/mod.rs
+++ b/crates/czsc-core/src/analyze/mod.rs
@@ -66,15 +66,15 @@ fn resolve_env_usize(explicit: usize, upper: &str, lower: &str, default: usize) 
     if explicit > 0 {
         return explicit;
     }
-    if let Ok(v) = std::env::var(upper) {
-        if let Ok(n) = v.trim().parse::<f64>() {
-            return n as usize;
-        }
+    if let Ok(v) = std::env::var(upper)
+        && let Ok(n) = v.trim().parse::<f64>()
+    {
+        return n as usize;
     }
-    if let Ok(v) = std::env::var(lower) {
-        if let Ok(n) = v.trim().parse::<f64>() {
-            return n as usize;
-        }
+    if let Ok(v) = std::env::var(lower)
+        && let Ok(n) = v.trim().parse::<f64>()
+    {
+        return n as usize;
     }
     default
 }


### PR DESCRIPTION
## Summary

- Fix the GitHub Actions `Code Linting` failure from `cargo clippy --workspace --all-targets -- -D warnings`.
- Collapse the two nested environment-variable parse checks in `resolve_env_usize` as requested by clippy.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

Related to SKZ-24.
