### PR TITLE
SKZ-456: Fix naive lightweight chart timestamps

### DIFF
--- a/czsc/utils/plotting/lightweight/_data.py
+++ b/czsc/utils/plotting/lightweight/_data.py
@@ -102,10 +102,13 @@ class ChartPayload:
 # -- 构造逻辑 ------------------------------------------------------------------
 
 
+_NAIVE_CHINA_TIME_OFFSET_SECONDS = 8 * 60 * 60
+
+
 def _ts(dt: Any) -> int:
-    """pd.Timestamp / datetime → unix 秒整数。"""
+    """无时区中国交易时间 → lightweight-charts 使用的 UTC 秒整数。"""
     if hasattr(dt, "timestamp"):
-        return int(dt.timestamp())
+        return int(dt.timestamp()) - _NAIVE_CHINA_TIME_OFFSET_SECONDS
     raise TypeError(f"unsupported dt type: {type(dt)!r}")
 
 

--- a/czsc/utils/plotting/lightweight/_data.py
+++ b/czsc/utils/plotting/lightweight/_data.py
@@ -10,6 +10,7 @@ import math
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any, TypedDict, cast
+from zoneinfo import ZoneInfo
 
 import numpy as np
 
@@ -102,13 +103,15 @@ class ChartPayload:
 # -- 构造逻辑 ------------------------------------------------------------------
 
 
-_NAIVE_CHINA_TIME_OFFSET_SECONDS = 8 * 60 * 60
+_CHINA_TIMEZONE = ZoneInfo("Asia/Shanghai")
 
 
 def _ts(dt: Any) -> int:
-    """无时区中国交易时间 → lightweight-charts 使用的 UTC 秒整数。"""
+    """将时间转换为 UTC epoch；无时区输入按中国交易时间解释。"""
     if hasattr(dt, "timestamp"):
-        return int(dt.timestamp()) - _NAIVE_CHINA_TIME_OFFSET_SECONDS
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_CHINA_TIMEZONE)
+        return int(dt.timestamp())
     raise TypeError(f"unsupported dt type: {type(dt)!r}")
 
 

--- a/czsc/utils/plotting/lightweight/_signals.py
+++ b/czsc/utils/plotting/lightweight/_signals.py
@@ -7,10 +7,11 @@ Streamlit 端共用同一份序列化结果。
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import pandas as pd
 
+from ._data import _ts
 from ._theme import classify_direction, direction_color
 
 __all__ = [
@@ -66,9 +67,8 @@ def detect_transitions(
         if cur != prev_value:
             v1 = cur.split("_", 1)[0]
             direction = classify_direction(v1)
-            dt = row["dt"]
-            # 兼容 pd.Timestamp / datetime / ISO 字符串三种 dt 表达
-            ts = int(dt.timestamp()) if hasattr(dt, "timestamp") else int(pd.Timestamp(dt).timestamp())
+            dt: Any = row["dt"]
+            ts = _ts(pd.Timestamp(dt))
             markers.append(
                 SignalMarker(
                     time=ts,

--- a/tests/test_lightweight_plotting.py
+++ b/tests/test_lightweight_plotting.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import math
 import re
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -50,6 +51,12 @@ def _payload_dict(c: CZSC) -> dict[str, Any]:
 
 
 class TestBuildFromCzsc:
+    def test_naive_datetime_is_shifted_to_utc_for_lightweight_charts(self):
+        """无时区的中国交易时间应以 UTC 秒值传给图表库。"""
+        dt = datetime(2024, 1, 2, 9, 30)
+
+        assert _data._ts(dt) == int(dt.timestamp()) - 8 * 60 * 60
+
     def test_candle_count_equals_bars_raw(self, czsc_30m: CZSC):
         payload = _data.build_from_czsc(czsc_30m)
         pane = payload.panes[0]
@@ -60,7 +67,9 @@ class TestBuildFromCzsc:
         payload = _data.build_from_czsc(czsc_30m)
         pane = payload.panes[0]
         # 同 time 去重后两边数量应一致（czsc 不会出现真同 time 重复 FX）
-        fx_pairs = sorted({(int(fx.dt.timestamp()), float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0])
+        fx_pairs = sorted(
+            {(int(fx.dt.timestamp()) - 8 * 60 * 60, float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0]
+        )
         assert len(pane.main.fx_line) == len({t for t, _ in fx_pairs})
         # 时间严格升序
         times = [pt["time"] for pt in pane.main.fx_line]

--- a/tests/test_lightweight_plotting.py
+++ b/tests/test_lightweight_plotting.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import re
-from datetime import datetime
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import pytest
@@ -47,15 +50,43 @@ def _payload_dict(c: CZSC) -> dict[str, Any]:
     return _data.build_from_czsc(c).to_dict()
 
 
+_SHANGHAI_TZ = timezone(timedelta(hours=8))
+
+
+def _shanghai_naive_to_utc_epoch(dt: datetime) -> int:
+    """将无时区中国交易时间转换为固定 UTC epoch，不读取宿主时区。"""
+    return int(dt.replace(tzinfo=_SHANGHAI_TZ).timestamp())
+
+
+@contextmanager
+def _host_timezone(tz: str):
+    """临时切换宿主时区，验证时间转换不依赖进程环境。"""
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+
 # ---------- L1 数据准备层 -----------------------------------------------------
 
 
 class TestBuildFromCzsc:
-    def test_naive_datetime_is_shifted_to_utc_for_lightweight_charts(self):
-        """无时区的中国交易时间应以 UTC 秒值传给图表库。"""
+    @pytest.mark.skipif(not hasattr(time, "tzset"), reason="requires time.tzset")
+    def test_naive_datetime_uses_fixed_utc_epoch_across_host_timezones(self):
+        """无时区中国交易时间的 UTC epoch 不得受宿主 TZ 影响。"""
         dt = datetime(2024, 1, 2, 9, 30)
+        expected = 1_704_159_000
 
-        assert _data._ts(dt) == int(dt.timestamp()) - 8 * 60 * 60
+        for host_tz in ("UTC", "Asia/Shanghai"):
+            with _host_timezone(host_tz):
+                assert _data._ts(dt) == expected
 
     def test_candle_count_equals_bars_raw(self, czsc_30m: CZSC):
         payload = _data.build_from_czsc(czsc_30m)
@@ -67,9 +98,7 @@ class TestBuildFromCzsc:
         payload = _data.build_from_czsc(czsc_30m)
         pane = payload.panes[0]
         # 同 time 去重后两边数量应一致（czsc 不会出现真同 time 重复 FX）
-        fx_pairs = sorted(
-            {(int(fx.dt.timestamp()) - 8 * 60 * 60, float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0]
-        )
+        fx_pairs = sorted({(_shanghai_naive_to_utc_epoch(fx.dt), float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0])
         assert len(pane.main.fx_line) == len({t for t, _ in fx_pairs})
         # 时间严格升序
         times = [pt["time"] for pt in pane.main.fx_line]

--- a/tests/test_lightweight_plotting.py
+++ b/tests/test_lightweight_plotting.py
@@ -88,6 +88,12 @@ class TestBuildFromCzsc:
             with _host_timezone(host_tz):
                 assert _data._ts(dt) == expected
 
+    def test_aware_datetime_keeps_its_own_timezone_semantics(self):
+        """带时区输入必须保留其时区语义，不应按中国交易时间重解释。"""
+        dt = datetime(2024, 1, 2, 9, 30, tzinfo=timezone(timedelta(hours=-5)))
+
+        assert _data._ts(dt) == 1_704_205_800
+
     def test_candle_count_equals_bars_raw(self, czsc_30m: CZSC):
         payload = _data.build_from_czsc(czsc_30m)
         pane = payload.panes[0]

--- a/tests/test_lightweight_signals.py
+++ b/tests/test_lightweight_signals.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json  # noqa: F401  - 后续 task 使用
 import math  # noqa: F401  - 后续 task 使用
 import re  # noqa: F401  - 后续 task 使用
+from datetime import datetime
 from typing import Any  # noqa: F401  - 后续 task 使用
 
 import pandas as pd  # noqa: F401  - 后续 task 使用
@@ -15,6 +16,7 @@ import pytest  # noqa: F401  - 后续 task 使用
 
 from czsc import Freq, format_standard_kline  # noqa: F401  - 后续 task 使用
 from czsc.mock import generate_symbol_kines  # noqa: F401  - 后续 task 使用
+from czsc.utils.plotting.lightweight import _data
 
 
 class TestPaletteConstants:
@@ -93,7 +95,19 @@ class TestDetectTransitions:
         df = self._df(["A_x_x_0", "A_x_x_0", "B_x_x_0", "B_x_x_0", "C_x_x_0"])
         markers = detect_transitions(df, "30分钟_D1_X", include_others=False)
         assert [m["v1"] for m in markers] == ["A", "B", "C"]
-        assert [m["time"] for m in markers] == [int(df["dt"].iloc[i].timestamp()) for i in (0, 2, 4)]
+        assert [m["time"] for m in markers] == [
+            _data._ts(df["dt"].iloc[i]) for i in (0, 2, 4)
+        ]
+
+    def test_marker_time_uses_chart_timestamp_contract(self):
+        """signal marker 与 K 线必须复用同一无时区 UTC 转换契约。"""
+        from czsc.utils.plotting.lightweight._signals import detect_transitions
+
+        dt = datetime(2024, 1, 2, 9, 30)
+        df = pd.DataFrame({"dt": [dt], "30分钟_D1_X": ["向上_任意_任意_0"]})
+
+        marker = detect_transitions(df, "30分钟_D1_X")[0]
+        assert marker["time"] == _data._ts(dt) == 1_704_159_000
 
     def test_u2_other_filtered_by_default(self):
         from czsc.utils.plotting.lightweight._signals import detect_transitions


### PR DESCRIPTION
Closes SKZ-456

## 实现
- `_data._ts` 现在将 naive `datetime` / `pandas.Timestamp` 显式赋予 `ZoneInfo("Asia/Shanghai")`，再生成 UTC epoch，消除对宿主 `TZ` 的依赖。
- aware 时间保持其自身时区语义。
- `_signals.detect_transitions` 通过 `_data._ts` 序列化 marker 时间，确保与 K 线、成交量、MACD、分型和笔共用同一转换入口。

## 回归覆盖
- 固定 `2024-01-02 09:30` 的 UTC epoch 为 `1704159000`，在 `TZ=UTC` 与 `TZ=Asia/Shanghai` 下均验证。
- 覆盖 aware 时间保留原时区语义。
- 覆盖 signal marker 与 `_data._ts(dt)` 一致，以及既有 pane/candle 对齐集成断言。

## 验证
- `uv run pytest tests/test_lightweight_plotting.py tests/test_lightweight_signals.py -q`：56 passed
- `uv run ruff check czsc/utils/plotting/lightweight/_data.py czsc/utils/plotting/lightweight/_signals.py tests/test_lightweight_plotting.py tests/test_lightweight_signals.py`：All checks passed
- `uv run python -m compileall -q czsc/utils/plotting/lightweight`：通过
- `basedpyright` 未发现本变更新增问题；仍报告既有的 `czsc._native.ta` 原生扩展导入解析错误。

请复审时重点确认：naive/aware 转换契约、signal marker 与 candle 共用入口、跨宿主时区回归覆盖。