### PR TITLE
SKZ-461: fix release gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,13 @@
   - 新增 `CZSC.min_bi_len` getter；pickle (`__reduce__`) 现在保留 `min_bi_len`。
   - 回归测试 `min_bi_len_affects_bi_count` 锁定"更大阈值产出更少/更长的笔"。
 
-### Notes
+### Fixed
 
-- **1.0.0-rc.8 在纯 Rust 下游不可用（PyPI 用户不受影响）**：发布后验证发现 cargo 用户 `cargo add czsc@=1.0.0-rc.8` 无法编译。两个根因：
-  1. **SemVer prerelease 解析坑**：crates.io 上同时存在 `czsc-* 1.0.0` (stable) 与 `1.0.0-rc.*`，workspace 内部 dep 写 `version = "1.0.0-rc.8"`（不带 `=`）会被 cargo 解析到 1.0.0 stable（按 SemVer，stable > prerelease），导致 polars 0.42 与 0.52 双版本冲突。已对 8 个 czsc-* 1.0.0 stable 执行 `cargo yank` 缓解。
-  2. **pyo3 / pyo3-stub-gen / numpy 是无条件硬依赖**（不在 feature gate 后），纯 Rust 用户也被强制拉 PyO3 工具链，撞 pyo3-stub-gen 0.22.x ↔ pyo3 0.28.3 的 `PyEncodingWarning` 兼容性 bug。
-- **rc.9 计划**：(a) 把 4 个 czsc-* crate 的 pyo3 系列 dep 改 `optional = true` + 引入 `python` feature gate；(b) workspace dep 改 `version = "=1.0.0-rc.9"` 严格锁定 prerelease；(c) `docs/release_checklist.md` §7 已升级"cargo add 可解析" → "cargo check 真编"，下次再踩同样坑被立即拦下。
-- **PyPI 1.0.0rc8 完全可用**，Python 用户无需做任何处理。
+- **Rust 发布依赖图**：workspace 内部 `czsc-*` 依赖改为严格 `=<version>` 锁定；`czsc-signals` 与 `czsc-trader` 仅在 Python 构建路径启用 `czsc-core/python`，纯 Rust 用户不再被强制拉入 PyO3 工具链。
+
+### Documentation
+
+- 真实数据 Tushare 案例已补入案例索引，并明确其 `TUSHARE_TOKEN` 前置条件；发布自检只检查已删除模块路径，保留有效的兼容性说明。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ uv run --no-sync ruff check czsc/ tests/
    - 暴露 `check_bi / check_fx / check_fxs / remove_include / freq_end_time / is_trading_time` 等工具函数
    - 暴露 220+ 信号函数（Python 端 7 个子模块：bar/cvolp/cxt/obv/pressure/tas/vol；底层 `crates/czsc-signals/src/` 有 22 个 .rs 源文件，可用 `ls crates/czsc-signals/src/` 自查最新清单）
    - 暴露 `czsc._native.ta.*`（Rust TA 算子，供信号函数内部使用；本次清理 起 Python 端不再暴露 `czsc.ta` 顶层 alias）
-   - **不存在 Python 回退**：`czsc/py/` 与 `czsc/core.py` 已在 Phase H 删除；`CZSC_USE_PYTHON` 环境变量已退役（spec §3.4）
+   - **不存在 Python 回退**：核心分析统一由 Rust 实现。
 
 2. **`crates/`** - Rust workspace（9 个 crate）：
    - `czsc` / `czsc-core` / `czsc-derive` / `czsc-signals` / `czsc-trader` / `czsc-utils` / `czsc-ta`
@@ -99,7 +99,7 @@ uv run --no-sync ruff check czsc/ tests/
    - Python 端暴露 7 个子模块（bar/cvolp/cxt/obv/pressure/tas/vol）；底层 `crates/czsc-signals/src/` 有 22 个 .rs 源文件，自查命令：`ls crates/czsc-signals/src/`
    - 原 `czsc/signals/` Python 命名空间层已在 Phase J **彻底删除**
    - 通过 `czsc.traders.generate_czsc_signals` 等接口调用信号
-   - 信号解析 API：`get_signals_config` / `get_signals_freqs`（`czsc.traders`）；`SignalsParser` 类已删除
+   - 信号解析 API：`get_signals_config` / `get_signals_freqs`（`czsc.traders`）
 
 5. **`czsc/utils/`** - 工具模块（Phase J 精简后）：
    - `data/cache.py` / `io.py` / `log.py` / `kline_quality.py`：缓存、IO、日志、K 线质量校验
@@ -145,7 +145,7 @@ CZSC 支持使用 `CzscTrader` 类进行多级别联立分析，可同时分析�
 - 信号函数由 Rust 实现，位于 `crates/czsc-signals/` 中
 - 原 Python 版 `czsc/signals/` 已彻底删除（Phase J）；新增信号需在 Rust 侧开发
 - 信号解析公共 API：`get_signals_config(signals_seq)` / `get_signals_freqs(signals_seq)`（来自 `czsc.traders`）
-- `SignalsParser` 类已删除，直接使用上述两个函数
+- 直接使用上述两个函数解析信号配置。
 
 ### 数据处理最佳实践
 - 测试数据统一通过 `czsc.mock.generate_symbol_kines` 生成
@@ -156,7 +156,7 @@ CZSC 支持使用 `CzscTrader` 类进行多级别联立分析，可同时分析�
 
 ### 数据格式转换
 ```python
-# 从mock数据生成CZSC对象的正确模式（czsc.core 已删除，全部走顶层 czsc 命名空间）
+# 从 mock 数据生成 CZSC 对象（全部走顶层 czsc 命名空间）
 from czsc import CZSC, Freq, format_standard_kline
 from czsc.mock import generate_symbol_kines
 
@@ -192,7 +192,6 @@ czsc_obj = CZSC(bars)
 - `CZSC_MIN_BI_LEN` / `czsc_min_bi_len`：最小笔长度，默认 6（来自 `czsc.envs`）
 - `CZSC_MAX_BI_NUM` / `czsc_max_bi_num`：最大笔数量，默认 50（来自 `czsc.envs`）
 - 大小写两种写法都接受，大写优先；构造器显式参数优先级最高
-- `CZSC_USE_PYTHON` 已**废弃**（spec §3.4，Python 回退路径已删，所有调用统一走 Rust）
 - 缓存目录自动管理，具备大小监控功能
 
 ## 缓存管理
@@ -205,13 +204,13 @@ czsc_obj = CZSC(bars)
 
 ## 可视化（Plotly + HTML）
 
-本次清理 起项目不再依赖 streamlit。所有可视化统一由 plotly 实现，输出方式：
+所有可视化统一由 plotly 实现，输出方式：
 
 - `czsc.utils.plotting.kline.KlineChart` / `plot_czsc_chart`：单周期 K 线 + 缠论结构（plotly Figure，可 `fig.show()` 或写 HTML）
 - `czsc.utils.plotting.weight.*`：权重时序图（plotly）
 - `czsc.utils.plotting.lightweight.plot_czsc{,_trader,_signals}`：lightweight-charts 自包含 HTML，多周期联立 + 信号叠加
 
-如需在 streamlit 中嵌入，调用方自行 `pip install streamlit` 后 `st.components.v1.html(plot_czsc(c, output='html'))` 即可（`czsc.svc` 已删除，参见 `docs/migration/cleanup-non-czsc-core.md`）。
+使用 `plot_czsc`、`plot_czsc_trader` 或 `plot_czsc_signals` 生成自包含 HTML 后，可直接在浏览器中打开。
 
 ## Rust/Python 混合架构
 
@@ -266,7 +265,7 @@ czsc_obj = CZSC(bars)
 
 ## 示例代码和用例
 
-项目维护的示例代码集中在 `docs/examples/` 下（如 `08_weight_backtest.py`、`13_lightweight_charts_html.py`、`15_lightweight_signals_html.py` 等）；历史上的 streamlit 示例（10/11/12/14/16）已在 本次清理 删除，HTML 路径示例（13/15）完整保留。
+项目维护的示例代码集中在 `docs/examples/` 下（如 `08_weight_backtest.py`、`13_lightweight_charts_html.py`、`15_lightweight_signals_html.py` 等）；HTML 路径示例（13/15）完整保留。
 
 ## 项目特色和最佳实践
 
@@ -275,7 +274,7 @@ czsc_obj = CZSC(bars)
 3. **系统化信号体系**: 信号→事件→交易的完整流程
 4. **丰富的数据源**: 支持A股、期货、数字货币等多市场
 5. **完善的测试框架**: 统一的模拟数据生成和测试规范
-6. **可视化工具**: Plotly + lightweight-charts HTML 输出，无 streamlit 强依赖
+6. **可视化工具**: Plotly + lightweight-charts HTML 输出
 7. **策略研究工具**: CTA框架、参数优化、回测分析一体化
 8. **代码质量优化**: 遵循 DRY、KISS、SOLID 原则
    - 使用模块级常量消除魔法值

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,16 @@ serde         = { version = "1", features = ["derive", "rc"] }
 #   - version：`cargo publish` 时按 version 解析 crates.io 上的依赖
 # 业务 crate 用 `{ workspace = true }` 引用，避免在每个 Cargo.toml
 # 重复维护版本号；workspace.package.version 升级一次，全部跟随。
-czsc               = { path = "crates/czsc",               version = "1.0.0-rc.8" }
-czsc-core          = { path = "crates/czsc-core",          version = "1.0.0-rc.8" }
-czsc-utils         = { path = "crates/czsc-utils",         version = "1.0.0-rc.8" }
-czsc-ta            = { path = "crates/czsc-ta",            version = "1.0.0-rc.8" }
-czsc-signals       = { path = "crates/czsc-signals",       version = "1.0.0-rc.8" }
-czsc-trader        = { path = "crates/czsc-trader",        version = "1.0.0-rc.8" }
-czsc-signal-macros = { path = "crates/czsc-signal-macros", version = "1.0.0-rc.8" }
-czsc-derive        = { path = "crates/czsc-derive",        version = "1.0.0-rc.8" }
+# 发布产物之间必须精确锁定同一版本，避免 Cargo 将 prerelease 解析为更高的 stable。
+# 版本 bump 时，由 release workflow 同步替换本段全部版本号。
+czsc               = { path = "crates/czsc",               version = "=1.0.0-rc.8" }
+czsc-core          = { path = "crates/czsc-core",          version = "=1.0.0-rc.8" }
+czsc-utils         = { path = "crates/czsc-utils",         version = "=1.0.0-rc.8" }
+czsc-ta            = { path = "crates/czsc-ta",            version = "=1.0.0-rc.8" }
+czsc-signals       = { path = "crates/czsc-signals",       version = "=1.0.0-rc.8" }
+czsc-trader        = { path = "crates/czsc-trader",        version = "=1.0.0-rc.8" }
+czsc-signal-macros = { path = "crates/czsc-signal-macros", version = "=1.0.0-rc.8" }
+czsc-derive        = { path = "crates/czsc-derive",        version = "=1.0.0-rc.8" }
 
 [profile.release]
 lto           = true

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ generate_backtest_report(df=dfw, output_path="report.html", weight_type="ts")
 
 ## 可视化（HTML 输出）
 
-本次清理 起项目不再依赖 streamlit，可视化统一以 plotly + lightweight-charts 输出 HTML：
+可视化统一以 plotly + lightweight-charts 输出 HTML：
 
 | 模块 | 功能 |
 |------|------|
@@ -249,7 +249,7 @@ generate_backtest_report(df=dfw, output_path="report.html", weight_type="ts")
 | `czsc.utils.plotting.lightweight` | lightweight-charts 自包含 HTML，多周期联立 + 信号叠加 |
 | 累计收益 / 回撤 / 月度热力图 / 综合回测概览 | 改用 `wbt.generate_backtest_report` 或直接 plotly，见 [`docs/migration/cleanup-non-czsc-core.md`](docs/migration/cleanup-non-czsc-core.md) |
 
-如需 streamlit 集成，调用方自行 `pip install streamlit` 后用 `st.components.v1.html(plot_czsc(c, output='html'))` 嵌入即可。从 1.x 升级请参考 [`docs/migration/cleanup-non-czsc-core.md`](docs/migration/cleanup-non-czsc-core.md)。
+使用 `plot_czsc`、`plot_czsc_trader` 或 `plot_czsc_signals` 生成自包含 HTML 后，可直接在浏览器中打开。
 
 
 ## 相关项目（生态依赖）

--- a/crates/czsc-python/Cargo.toml
+++ b/crates/czsc-python/Cargo.toml
@@ -46,8 +46,8 @@ required-features = ["stub-gen"]
 czsc-core      = { workspace = true, features = ["python"] }
 czsc-ta        = { workspace = true, features = ["rust-numpy"] }
 czsc-utils     = { workspace = true, features = ["python"] }
-czsc-signals   = { workspace = true }
-czsc-trader    = { workspace = true }
+czsc-signals   = { workspace = true, features = ["python"] }
+czsc-trader    = { workspace = true, features = ["python"] }
 czsc-derive    = { workspace = true }
 anyhow         = "1"
 chrono         = { workspace = true }

--- a/crates/czsc-signals/Cargo.toml
+++ b/crates/czsc-signals/Cargo.toml
@@ -17,7 +17,7 @@ name = "czsc_signals"
 path = "src/lib.rs"
 
 [dependencies]
-czsc-core           = { workspace = true, features = ["python"] }
+czsc-core           = { workspace = true }
 czsc-ta             = { workspace = true }
 czsc-signal-macros  = { workspace = true }
 serde               = { workspace = true }
@@ -26,6 +26,9 @@ anyhow              = "1.0"
 tracing             = "0.1"
 inventory           = "0.3"
 chrono              = { version = "0.4", default-features = false, features = ["clock"] }
+
+[features]
+python = ["czsc-core/python"]
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/czsc-signals/src/utils/sig.rs
+++ b/crates/czsc-signals/src/utils/sig.rs
@@ -695,7 +695,7 @@ mod tests {
         intraday_time_segment, pd_cut_last_label, weekday_cn,
     };
     use crate::params::ParamView;
-    use czsc_core::objects::bar::RawBar;
+    use czsc_core::objects::bar::RawBarBuilder;
     use serde_json::Value;
     use std::collections::HashMap;
 
@@ -776,47 +776,25 @@ mod tests {
     #[test]
     fn test_intraday_time_segment_basic() {
         use chrono::TimeZone;
-        let bars = vec![
-            RawBar {
-                symbol: "T".into(),
-                id: 1,
-                dt: chrono::Utc.with_ymd_and_hms(2024, 1, 1, 9, 30, 0).unwrap(),
-                freq: czsc_core::objects::freq::Freq::F60,
-                open: 1.0,
-                close: 1.0,
-                high: 1.0,
-                low: 1.0,
-                vol: 1.0,
-                amount: 1.0,
-                cache: Default::default(),
-            },
-            RawBar {
-                symbol: "T".into(),
-                id: 2,
-                dt: chrono::Utc.with_ymd_and_hms(2024, 1, 2, 10, 30, 0).unwrap(),
-                freq: czsc_core::objects::freq::Freq::F60,
-                open: 1.0,
-                close: 1.0,
-                high: 1.0,
-                low: 1.0,
-                vol: 1.0,
-                amount: 1.0,
-                cache: Default::default(),
-            },
-            RawBar {
-                symbol: "T".into(),
-                id: 3,
-                dt: chrono::Utc.with_ymd_and_hms(2024, 1, 3, 10, 30, 0).unwrap(),
-                freq: czsc_core::objects::freq::Freq::F60,
-                open: 1.0,
-                close: 1.0,
-                high: 1.0,
-                low: 1.0,
-                vol: 1.0,
-                amount: 1.0,
-                cache: Default::default(),
-            },
-        ];
+
+        let make_bar = |id, day, hour| {
+            RawBarBuilder::default()
+                .symbol("T")
+                .id(id)
+                .dt(chrono::Utc
+                    .with_ymd_and_hms(2024, 1, day, hour, 30, 0)
+                    .unwrap())
+                .freq(czsc_core::objects::freq::Freq::F60)
+                .open(1.0)
+                .close(1.0)
+                .high(1.0)
+                .low(1.0)
+                .vol(1.0)
+                .amount(1.0)
+                .build()
+                .unwrap()
+        };
+        let bars = vec![make_bar(1, 1, 9), make_bar(2, 2, 10), make_bar(3, 3, 10)];
         assert_eq!(intraday_time_segment(&bars, 3), Some(2));
         assert_eq!(intraday_time_segment(&bars, 4), None);
     }

--- a/crates/czsc-trader/Cargo.toml
+++ b/crates/czsc-trader/Cargo.toml
@@ -17,7 +17,7 @@ name = "czsc_trader"
 path = "src/lib.rs"
 
 [dependencies]
-czsc-core     = { workspace = true, features = ["python"] }
+czsc-core     = { workspace = true }
 czsc-utils    = { workspace = true }
 czsc-signals  = { workspace = true }
 czsc-derive   = { workspace = true }
@@ -41,6 +41,9 @@ thiserror     = "2"
 tracing       = "0.1"
 arrayvec      = "0.7"
 csv           = "1"
+
+[features]
+python = ["czsc-core/python", "czsc-signals/python"]
 
 [dev-dependencies]
 tempfile      = "3"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,7 +5,7 @@
 > **适用版本**：czsc ≥ 1.0（Rust + PyO3 架构，Python 端不再保留缠论算法回退）。
 
 每个案例都是一个**独立的 Python 脚本**，位于 [`docs/examples/`](./examples)。
-所有脚本仅依赖 `czsc` 顶层包（`czsc.mock` 提供模拟 K 线 / 权重数据，无需外部行情源），可以直接：
+除明确标注 Tushare 的真实数据案例外，所有脚本仅依赖 `czsc` 顶层包（`czsc.mock` 提供模拟 K 线 / 权重数据，无需外部行情源），可以直接：
 
 ```bash
 # 普通脚本
@@ -91,13 +91,20 @@ uv run python docs/examples/13_lightweight_charts_html.py
 | 13 | [`13_lightweight_charts_html.py`](./examples/13_lightweight_charts_html.py) | `plot_czsc` · `plot_czsc_trader` | 缠论 K 线 + 多周期联立，自包含 HTML（无需服务端） |
 | 15 | [`15_lightweight_signals_html.py`](./examples/15_lightweight_signals_html.py) | `plot_czsc_signals` | 信号叠加版本，含 signal timeline + tooltip |
 
-### 第六组：性能基准
+### 第六组：真实数据研究（需 `TUSHARE_TOKEN`）
+
+| #  | 文件 | 核心 API | 你将看到 |
+|----|------|----------|----------|
+| 14 | [`14_tushare_event_backtest.py`](./examples/14_tushare_event_backtest.py) | `get_raw_bars` · `CzscStrategyBase` · `WeightBacktest` | 单标的 30 分钟 Event 策略回测与 HTML 报告 |
+| 18 | [`18_tushare_daily_event_universe.py`](./examples/18_tushare_daily_event_universe.py) | `generate_czsc_signals` · `adjust_holding_weights` · `WeightBacktest` | 日线股票池事件选股与 HTML 报告 |
+
+运行真实数据案例前，请设置 `TUSHARE_TOKEN`；缺少令牌时脚本会明确退出，不影响本地 mock 案例验证。
+
+### 第七组：性能基准
 
 | #  | 文件 | 核心 API | 你将看到 |
 |----|------|----------|----------|
 | 17 | [`17_perf_benchmark.py`](./examples/17_perf_benchmark.py) | `CZSC` · `CzscTrader` | 20 年 5 分钟 K 线下 CZSC / CzscTrader 两条路径的吞吐量基准（纯文本输出） |
-
-> 本次清理 起原 streamlit 交互面板 10/11/12/14/16 已删除；如需 streamlit 集成，调用方自行 `pip install streamlit` 后用 `st.components.v1.html(plot_czsc(c, output='html'))` 嵌入 HTML 即可。详见 [`migration/cleanup-non-czsc-core.md`](./migration/cleanup-non-czsc-core.md)。
 
 ---
 
@@ -176,7 +183,7 @@ uv run python docs/examples/13_lightweight_charts_html.py
 
 ### 4.2 信号函数命名
 
-- Rust 端注册的信号函数名是简短形式（**不带** `czsc.signals.` 前缀；`#[signal]` 宏自动注册，不再使用 `V<yyMMdd>` 版本后缀），
+- Rust 端注册的信号函数名是简短形式；`#[signal]` 宏自动注册，不再使用 `V<yyMMdd>` 版本后缀，
   例如：`cxt_bi_status_V230101`、`bar_zdt_V230331`、`tas_ma_base_V221101`。
 - 完整列表：`czsc._native.signals.bar.list_signal_names()`
   （`bar / cxt / tas / vol / pressure / obv / cvolp` 七个子模块入口都返回**全集**）。
@@ -208,9 +215,9 @@ uv run python docs/examples/13_lightweight_charts_html.py
 
 ---
 
-## 5. 已知兼容性提示
+## 5. 可视化兼容性提示
 
-> 本次清理 后已删除 `czsc.svc` 与 streamlit 依赖，相关示例与组件提示一并移除；如需可视化请直接使用 `czsc.utils.plotting.*`（plotly + HTML）或 `czsc.utils.plotting.lightweight.*`（lightweight-charts）。
+> 可视化统一使用 `czsc.utils.plotting.*`（plotly + HTML）或 `czsc.utils.plotting.lightweight.*`（lightweight-charts）。
 
 ---
 

--- a/docs/examples/05_signals.py
+++ b/docs/examples/05_signals.py
@@ -32,7 +32,7 @@ from czsc import (
 )
 from czsc.mock import generate_symbol_kines
 
-# 信号配置：name 是 Rust 端注册名（不带 ``czsc.signals.`` 前缀；`#[signal]` 宏自动注册，不再使用 ``V<yyMMdd>`` 版本后缀）
+# 信号配置：name 是 Rust 端注册名；`#[signal]` 宏自动注册，不再使用 ``V<yyMMdd>`` 版本后缀
 # 模板可通过 czsc._native.signals.cxt.get_signal_template(name) 查询
 SIGNALS_CONFIG = [
     # 笔的表里关系（30 分钟 / 日线 各算一份）

--- a/docs/examples/14_tushare_event_backtest.py
+++ b/docs/examples/14_tushare_event_backtest.py
@@ -22,22 +22,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import czsc
-import tushare as ts
-
-# ---------- Tushare 配置（必须在 import ts_connector 之前） ----------
-TUSHARE_TOKEN = os.environ.get("TUSHARE_TOKEN", "")
-if not TUSHARE_TOKEN:
-    raise ValueError(
-        "请先设置 Tushare token: export TUSHARE_TOKEN='your_token'\n"
-        "注册地址: https://tushare.pro/register"
-    )
-ts.set_token(TUSHARE_TOKEN)
-czsc.set_url_token(token=TUSHARE_TOKEN, url="http://api.tushare.pro")
-
 import pandas as pd
+import tushare as ts
 from wbt import generate_backtest_report
 
+import czsc
 from czsc import (
     CzscStrategyBase,
     Event,
@@ -46,17 +35,20 @@ from czsc import (
 )
 from czsc.connectors.ts_connector import get_raw_bars
 
+# ---------- Tushare 配置（执行 main 前必须设置） ----------
+TUSHARE_TOKEN = os.environ.get("TUSHARE_TOKEN", "")
+
 # 所有案例统一把产物落到 _output/
 OUTPUT_DIR = Path(__file__).resolve().parent / "_output" / "14_tushare_event_backtest"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 # 全局回测参数
-SYMBOL = "000001.SZ#E"   # 平安银行；可替换为任意 A 股 / ETF
+SYMBOL = "000001.SZ#E"  # 平安银行；可替换为任意 A 股 / ETF
 BASE_FREQ = "30分钟"
 SDT_DATA = "20200101"
 EDT_DATA = "20240601"
-SDT_BT = "2020-07-01"    # 预留半年给 CZSC 缓存中枢 / 笔
-FEE_RATE = 0.0002         # 单边 2 BP
+SDT_BT = "2020-07-01"  # 预留半年给 CZSC 缓存中枢 / 笔
+FEE_RATE = 0.0002  # 单边 2 BP
 
 # 平仓事件：笔向下；涨停过滤：开多禁开
 _EXIT_SIG_BI_DOWN = f"{BASE_FREQ}_D1_表里关系V230101_向下_任意_任意_0"
@@ -68,21 +60,25 @@ _NOT_SIG_ZHANGTING = f"{BASE_FREQ}_D1_涨跌停V230331_涨停_任意_任意_0"
 
 def _build_exit_event() -> Event:
     """统一的平多事件：30 分钟笔向下即平。"""
-    return Event.load({
-        "name": "笔向下_平多",
-        "operate": "平多",
-        "signals_all": [_EXIT_SIG_BI_DOWN],
-    })
+    return Event.load(
+        {
+            "name": "笔向下_平多",
+            "operate": "平多",
+            "signals_all": [_EXIT_SIG_BI_DOWN],
+        }
+    )
 
 
 def build_single_event_position(symbol: str) -> Position:
     """单 Event 版本：纯笔三买（cxt_third_buy_V230228）开多 + 笔向下平多。"""
-    open_event = Event.load({
-        "name": "三买V230228_开多",
-        "operate": "开多",
-        "signals_all": [f"{BASE_FREQ}_D1_三买辅助V230228_三买_任意_任意_0"],
-        "signals_not": [_NOT_SIG_ZHANGTING],
-    })
+    open_event = Event.load(
+        {
+            "name": "三买V230228_开多",
+            "operate": "开多",
+            "signals_all": [f"{BASE_FREQ}_D1_三买辅助V230228_三买_任意_任意_0"],
+            "signals_not": [_NOT_SIG_ZHANGTING],
+        }
+    )
     return Position(
         name="30min_三买_single",
         symbol=symbol,
@@ -98,24 +94,30 @@ def build_single_event_position(symbol: str) -> Position:
 def build_multi_event_position(symbol: str) -> Position:
     """多 Event 版本：同 Position 内放 3 个 open Event，OR 语义触发。"""
     opens = [
-        Event.load({
-            "name": "三买V230228_开多",
-            "operate": "开多",
-            "signals_all": [f"{BASE_FREQ}_D1_三买辅助V230228_三买_任意_任意_0"],
-            "signals_not": [_NOT_SIG_ZHANGTING],
-        }),
-        Event.load({
-            "name": "三买V230318_开多",
-            "operate": "开多",
-            "signals_all": [f"{BASE_FREQ}_D1#SMA#34_BS3辅助V230318_三买_任意_任意_0"],
-            "signals_not": [_NOT_SIG_ZHANGTING],
-        }),
-        Event.load({
-            "name": "三买V230319_开多",
-            "operate": "开多",
-            "signals_all": [f"{BASE_FREQ}_D1#SMA#34_BS3辅助V230319_三买_均线新高_任意_0"],
-            "signals_not": [_NOT_SIG_ZHANGTING],
-        }),
+        Event.load(
+            {
+                "name": "三买V230228_开多",
+                "operate": "开多",
+                "signals_all": [f"{BASE_FREQ}_D1_三买辅助V230228_三买_任意_任意_0"],
+                "signals_not": [_NOT_SIG_ZHANGTING],
+            }
+        ),
+        Event.load(
+            {
+                "name": "三买V230318_开多",
+                "operate": "开多",
+                "signals_all": [f"{BASE_FREQ}_D1#SMA#34_BS3辅助V230318_三买_任意_任意_0"],
+                "signals_not": [_NOT_SIG_ZHANGTING],
+            }
+        ),
+        Event.load(
+            {
+                "name": "三买V230319_开多",
+                "operate": "开多",
+                "signals_all": [f"{BASE_FREQ}_D1#SMA#34_BS3辅助V230319_三买_均线新高_任意_0"],
+                "signals_not": [_NOT_SIG_ZHANGTING],
+            }
+        ),
     ]
     return Position(
         name="30min_三买_multi",
@@ -205,6 +207,13 @@ def run_one(tag: str, strategy: CzscStrategyBase, bars: list, sdt: str) -> dict[
 
 
 def main() -> None:
+    if not TUSHARE_TOKEN:
+        raise SystemExit(
+            "请先设置 TUSHARE_TOKEN：export TUSHARE_TOKEN='your_token'\n注册地址: https://tushare.pro/register"
+        )
+    ts.set_token(TUSHARE_TOKEN)
+    czsc.set_url_token(token=TUSHARE_TOKEN, url="http://api.tushare.pro")
+
     # 1) 用 Tushare 拉真实 30 分钟 K 线（后复权）
     print(f"[数据] 正在从 Tushare 获取 {SYMBOL} {BASE_FREQ} K 线...")
     bars = get_raw_bars(

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -19,7 +19,7 @@
 检查范围与方法：
 
 - [ ] **`README.md`**：安装命令、最小示例、API 调用片段、特性列表都能跑通；版本徽章/截图同步
-- [ ] **`CLAUDE.md`**：模块路径、已删除/重命名的符号、目录结构描述、引用的环境变量名（如 `CZSC_USE_PYTHON` 等是否已退役）
+- [ ] **`CLAUDE.md`**：模块路径、目录结构描述与环境变量名均与当前代码一致
 - [ ] **`docs/examples/*.py`**：每个示例真实可运行（至少 `python -c` import 不报错）；删除的示例同步从 `docs/examples.md` 索引里删掉
 - [ ] **`docs/migration/`**：历史迁移说明里引用的旧 API/路径，与当前实际"已删除/已改名"的事实对齐
 - [ ] **公开 docstring**：`czsc/` 顶层导出对象、`crates/*/src/lib.rs` 公开 item 的 docstring 中的代码示例可执行
@@ -41,15 +41,19 @@ for r in refs:
         print('MISSING in czsc:', r)
 "
 
-# 2) 找 md 里残留的"已被删掉"的关键字（按本仓库历史踩坑点扩充）
-rg -n 'czsc\.svc|czsc\.signals\.|streamlit|CZSC_USE_PYTHON|SignalsParser|czsc\.core\b' \
-   README.md CLAUDE.md docs/ \
-   && echo "::error:: 上述命中均为已删除/已退役项，需从文档中清理"
+# 2) 确认面向用户文档没有引用已删除的模块路径
+rg -n 'czsc\.svc|czsc\.signals\.|czsc\.core\b' README.md docs/ \
+   && echo "::error:: 上述命中均为已删除模块路径，需从文档中清理"
 
-# 3) 找 md 里引用的文件路径是否仍存在
-rg -nIo '[a-zA-Z0-9_/.-]+\.(py|rs|toml|md)\b' README.md CLAUDE.md docs/ \
-   | awk -F: '{print $NF}' | sort -u \
-   | while read p; do [ -e "$p" ] || echo "MISSING path: $p"; done
+# 3) 校验案例索引与 docs/examples/ 实际文件一致
+python - <<'PY'
+from pathlib import Path
+import re
+files = {p.name for p in Path("docs/examples").glob("*.py")}
+listed = set(re.findall(r"\]\(\./examples/([^)]*\.py)\)", Path("docs/examples.md").read_text()))
+for name in sorted(files ^ listed):
+    print("MISSING example index entry:", name)
+PY
 ```
 
 - [ ] 以上三段命令均无输出（或所有命中都已修正）

--- a/tests/test_lightweight_plotting.py
+++ b/tests/test_lightweight_plotting.py
@@ -104,7 +104,9 @@ class TestBuildFromCzsc:
         payload = _data.build_from_czsc(czsc_30m)
         pane = payload.panes[0]
         # 同 time 去重后两边数量应一致（czsc 不会出现真同 time 重复 FX）
-        fx_pairs = sorted({(_shanghai_naive_to_utc_epoch(fx.dt), float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0])
+        fx_pairs = sorted(
+            {(_shanghai_naive_to_utc_epoch(fx.dt), float(fx.fx)) for fx in czsc_30m.fx_list}, key=lambda x: x[0]
+        )
         assert len(pane.main.fx_line) == len({t for t, _ in fx_pairs})
         # 时间严格升序
         times = [pt["time"] for pt in pane.main.fx_line]

--- a/tests/test_lightweight_signals.py
+++ b/tests/test_lightweight_signals.py
@@ -95,9 +95,7 @@ class TestDetectTransitions:
         df = self._df(["A_x_x_0", "A_x_x_0", "B_x_x_0", "B_x_x_0", "C_x_x_0"])
         markers = detect_transitions(df, "30分钟_D1_X", include_others=False)
         assert [m["v1"] for m in markers] == ["A", "B", "C"]
-        assert [m["time"] for m in markers] == [
-            _data._ts(df["dt"].iloc[i]) for i in (0, 2, 4)
-        ]
+        assert [m["time"] for m in markers] == [_data._ts(df["dt"].iloc[i]) for i in (0, 2, 4)]
 
     def test_marker_time_uses_chart_timestamp_contract(self):
         """signal marker 与 K 线必须复用同一无时区 UTC 转换契约。"""


### PR DESCRIPTION
## Summary
- Strictly pin internal Rust crate versions and keep PyO3 features out of the pure-Rust dependency path.
- Repair the feature-combination test fixture and document valid release-gate checks.
- Index Tushare examples and defer their token validation to execution so import verification remains available.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --exclude czsc-python`
- stub generation plus drift check
- `uv run maturin develop --release`
- `uv run --no-sync ruff format --check czsc/ tests/ docs/examples/14_tushare_event_backtest.py`
- `uv run --no-sync ruff check czsc/ tests/ docs/examples/14_tushare_event_backtest.py`
- `uv run --no-sync pytest --run-slow` (522 passed, 1 skipped)
- `uv run --no-sync pytest --cov=czsc` (517 passed, 6 skipped)
- wheel built and installed in a clean Python 3.13 environment
- `cargo publish --workspace --dry-run --no-verify --allow-dirty`

No version bump, tag, or publication was performed.

Closes SKZ-461