### PR TITLE
SKZ-495：修复重复 FX 生成与聚合

### DIFF
--- a/crates/czsc-core/src/analyze/mod.rs
+++ b/crates/czsc-core/src/analyze/mod.rs
@@ -146,9 +146,13 @@ impl CZSC {
 
     /// 分型列表，包括 bars_ubi 中的分型
     pub fn get_fx_list(&self) -> Vec<FX> {
-        let mut fxs = Vec::new();
+        let mut fxs: Vec<FX> = Vec::new();
         for bi_ in self.bi_list.iter() {
-            fxs.extend_from_slice(&bi_.fxs[1..]);
+            for x in &bi_.fxs[1..] {
+                if fxs.is_empty() || x.dt > fxs.last().unwrap().dt {
+                    fxs.push(x.clone());
+                }
+            }
         }
 
         if let Some(ubi_fxs) = self.get_ubi_fxs() {

--- a/crates/czsc-core/src/analyze/utils.rs
+++ b/crates/czsc-core/src/analyze/utils.rs
@@ -269,7 +269,7 @@ pub fn check_fxs<B: AsRef<NewBar>>(bars: &[B]) -> Vec<FX> {
         {
             // 与Python版本保持一致：过滤重复的相同标记分型
             // 默认情况下，fxs本身是顶底交替的，但是对于一些特殊情况下不是这样; 临时强制要求fxs序列顶底交替
-            if fxs.len() >= 2 && fx1.mark == fxs.last().unwrap().mark {
+            if !fxs.is_empty() && fx1.mark == fxs.last().unwrap().mark {
                 eprintln!(
                     "check_fxs错误: {}，{:?}，{:?}",
                     k2.as_ref().dt,

--- a/crates/czsc-core/tests/test_analyze_utils.rs
+++ b/crates/czsc-core/tests/test_analyze_utils.rs
@@ -75,6 +75,44 @@ fn check_fxs_extracts_fx_from_sequence() {
 }
 
 #[test]
+fn check_fxs_keeps_first_of_adjacent_tops() {
+    let bars = vec![
+        nb(1, 10.0, 0.0),
+        nb(2, 12.0, 2.0),
+        nb(3, 11.0, 1.0),
+        nb(4, 11.5, 0.5),
+        nb(5, 13.0, 3.0),
+        nb(6, 10.0, 0.0),
+    ];
+
+    let fxs = check_fxs(&bars);
+
+    assert_eq!(fxs.len(), 1);
+    assert_eq!(fxs[0].mark, Mark::G);
+    assert_eq!(fxs[0].dt, Utc.timestamp_opt(2, 0).unwrap());
+    assert!(fxs.windows(2).all(|pair| pair[0].mark != pair[1].mark));
+}
+
+#[test]
+fn check_fxs_keeps_first_of_adjacent_bottoms() {
+    let bars = vec![
+        nb(1, 12.0, 2.0),
+        nb(2, 10.0, 0.0),
+        nb(3, 11.0, 1.0),
+        nb(4, 10.5, 1.5),
+        nb(5, 9.0, -1.0),
+        nb(6, 12.0, 2.0),
+    ];
+
+    let fxs = check_fxs(&bars);
+
+    assert_eq!(fxs.len(), 1);
+    assert_eq!(fxs[0].mark, Mark::D);
+    assert_eq!(fxs[0].dt, Utc.timestamp_opt(2, 0).unwrap());
+    assert!(fxs.windows(2).all(|pair| pair[0].mark != pair[1].mark));
+}
+
+#[test]
 fn check_bi_returns_none_for_monotone_sequence() {
     // 严格单调递增序列既无顶分型也无底分型，不满足笔的识别条件
     let bars: Vec<NewBar> = (0..6)

--- a/crates/czsc-core/tests/test_czsc_analyzer.rs
+++ b/crates/czsc-core/tests/test_czsc_analyzer.rs
@@ -43,6 +43,26 @@ fn synthetic_zigzag(n: usize) -> Vec<RawBar> {
         .collect()
 }
 
+fn seeded_bars(seed: u64, n: usize) -> Vec<RawBar> {
+    let mut state = seed;
+    let mut price = 100.0;
+    (0..n)
+        .map(|i| {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let delta = ((state >> 32) as i32 % 200) as f64 / 100.0;
+            price += delta;
+            let spread = 0.5 + ((state >> 48) % 100) as f64 / 100.0;
+            rb(
+                1_700_000_000 + (i as i64) * 1800,
+                price - 0.1,
+                price + 0.1,
+                price + spread,
+                price - spread,
+            )
+        })
+        .collect()
+}
+
 #[test]
 fn new_populates_symbol_and_freq() {
     let bars = synthetic_zigzag(50);
@@ -104,6 +124,36 @@ fn analyzer_clones_independently() {
     let d = c.clone();
     assert_eq!(d.bi_list.len(), c.bi_list.len());
     assert_eq!(&*d.symbol, &*c.symbol);
+}
+
+#[test]
+fn fx_list_deduplicates_shared_endpoint_between_finished_bis() {
+    let c = CZSC::new(seeded_bars(1, 80), 50, 6);
+    assert!(c.bi_list.len() >= 2);
+
+    let shared = c.bi_list[0].fxs.last().unwrap();
+    assert_eq!(shared, &c.bi_list[1].fxs[1]);
+
+    let fxs = c.get_fx_list();
+    assert_eq!(fxs.iter().filter(|fx| fx.dt == shared.dt).count(), 1);
+    assert_eq!(fxs.iter().find(|fx| fx.dt == shared.dt).unwrap(), shared);
+    assert!(fxs.windows(2).all(|pair| pair[0].dt < pair[1].dt));
+    assert!(fxs.windows(2).all(|pair| pair[0].mark != pair[1].mark));
+}
+
+#[test]
+fn fx_list_deduplicates_bi_to_ubi_boundary_and_keeps_later_ubi_fx() {
+    let c = CZSC::new(seeded_bars(1, 26), 50, 6);
+    let last_bi_fx = c.bi_list.last().unwrap().fxs.last().unwrap();
+    let ubi_fxs = c.get_ubi_fxs().unwrap();
+    assert_eq!(ubi_fxs.first().unwrap().dt, last_bi_fx.dt);
+    let later_ubi_fx = ubi_fxs.iter().find(|fx| fx.dt > last_bi_fx.dt).unwrap();
+
+    let fxs = c.get_fx_list();
+    assert_eq!(fxs.iter().filter(|fx| fx.dt == last_bi_fx.dt).count(), 1);
+    assert!(fxs.iter().any(|fx| fx == later_ubi_fx));
+    assert_eq!(fxs.last().unwrap(), later_ubi_fx);
+    assert!(fxs.windows(2).all(|pair| pair[0].dt < pair[1].dt));
 }
 
 /// min_bi_len 必须真正作用于成笔逻辑：更大的阈值会过滤掉更短的笔，


### PR DESCRIPTION
## 变更说明

- 修正 `check_fxs` 的边界条件，从第二个候选开始过滤相邻同标记分型并保留先出现项
- `get_fx_list` 统一按严格递增时间聚合已完成 BI，消除相邻 BI 的共享端点重复
- 增加 `G,G`、`D,D` 以及真实 RawBar→CZSC 的 BI→BI、BI→UBI 回归测试

## TDD 证据

- `G,G`：旧实现实际 2、期望 1，修复后通过
- `D,D`：旧实现实际 2、期望 1，修复后通过
- BI→BI：旧实现共享端点出现 2 次、期望 1，聚合修复后通过
- BI→UBI：确认等时端点只保留一次，较晚 UBI 分型仍保留

## 验证

- `cargo test -p czsc-core --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy -q -p czsc-core --all-targets -- -D warnings`
- `git diff --check`

Closes SKZ-495