### PR TITLE
SKZ-506: 优化 README 推广区视觉层级

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@
 **[信号函数编写规范](https://s0cqcxuy3p.feishu.cn/wiki/wikcnCFLLTNGbr2THqo7KtWfBkd)** |
 **[DEVIN生成的文档](https://deepwiki.com/waditu/czsc/1-overview)**
 
-<div align="center">
+<table width="100%">
+  <tr>
+    <td align="center">
   <strong>胜可知 · 大模型量化策略研究平台（内测）</strong><br>
   <sub>使用大模型辅助量化策略研究，当前重点支持时序量价择时策略</sub><br><br>
   <a href="https://quant.shengkezhi.com/"><img alt="立即注册 · 领取 500 元额度" src="https://img.shields.io/static/v1?label=%E7%AB%8B%E5%8D%B3%E6%B3%A8%E5%86%8C&message=%E9%A2%86%E5%8F%96%20500%20%E5%85%83%E9%A2%9D%E5%BA%A6&color=2ea44f&style=for-the-badge"></a><br>
   <sub>邀请码：<code>5862EDBH2H9CDTGZ</code></sub><br><br>
   <a href="https://docs.shengkezhi.com/new-user-roadmap">新手路线</a> · <a href="https://docs.shengkezhi.com/research-methodology">研究方法</a> · <a href="https://s0cqcxuy3p.feishu.cn/minutes/obcn6m8m44515zvn24ltmu3y">使用案例</a> · <a href="https://www.shengkezhi.com/">产品介绍</a>
-</div>
+    </td>
+  </tr>
+</table>
 
 > **1.0.X 版本开始，缠论核心算法（分型、笔、中枢等）已全部迁移到 Rust 实现，通过 PyO3 扩展（`czsc._native`）暴露给 Python。** 需要了解旧 Python 实现逻辑的，可查看 [0.9.X](https://github.com/waditu/czsc/tree/v0.9.69) 版本。
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@
 **[信号函数编写规范](https://s0cqcxuy3p.feishu.cn/wiki/wikcnCFLLTNGbr2THqo7KtWfBkd)** |
 **[DEVIN生成的文档](https://deepwiki.com/waditu/czsc/1-overview)**
 
-## 大模型量化策略研究平台（内测）
-
-> **胜可知量化研究平台正在内测**：使用大模型辅助量化策略研究，当前重点支持时序量价择时策略。注册即赠 500 元使用额度，邀请码：`5862EDBH2H9CDTGZ`。
-
-**[立即注册](https://quant.shengkezhi.com/)** | 新手入门：[使用路线](https://docs.shengkezhi.com/new-user-roadmap) · [研究方法](https://docs.shengkezhi.com/research-methodology) | [使用案例](https://s0cqcxuy3p.feishu.cn/minutes/obcn6m8m44515zvn24ltmu3y) | [产品介绍](https://www.shengkezhi.com/)
+<div align="center">
+  <strong>胜可知 · 大模型量化策略研究平台（内测）</strong><br>
+  <sub>使用大模型辅助量化策略研究，当前重点支持时序量价择时策略</sub><br><br>
+  <a href="https://quant.shengkezhi.com/"><img alt="立即注册 · 领取 500 元额度" src="https://img.shields.io/static/v1?label=%E7%AB%8B%E5%8D%B3%E6%B3%A8%E5%86%8C&message=%E9%A2%86%E5%8F%96%20500%20%E5%85%83%E9%A2%9D%E5%BA%A6&color=2ea44f&style=for-the-badge"></a><br>
+  <sub>邀请码：<code>5862EDBH2H9CDTGZ</code></sub><br><br>
+  <a href="https://docs.shengkezhi.com/new-user-roadmap">新手路线</a> · <a href="https://docs.shengkezhi.com/research-methodology">研究方法</a> · <a href="https://s0cqcxuy3p.feishu.cn/minutes/obcn6m8m44515zvn24ltmu3y">使用案例</a> · <a href="https://www.shengkezhi.com/">产品介绍</a>
+</div>
 
 > **1.0.X 版本开始，缠论核心算法（分型、笔、中枢等）已全部迁移到 Rust 实现，通过 PyO3 扩展（`czsc._native`）暴露给 Python。** 需要了解旧 Python 实现逻辑的，可查看 [0.9.X](https://github.com/waditu/czsc/tree/v0.9.69) 版本。
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **[信号函数编写规范](https://s0cqcxuy3p.feishu.cn/wiki/wikcnCFLLTNGbr2THqo7KtWfBkd)** |
 **[DEVIN生成的文档](https://deepwiki.com/waditu/czsc/1-overview)**
 
-<table width="100%">
+<table>
   <tr>
     <td align="center">
   <strong>胜可知 · 大模型量化策略研究平台（内测）</strong><br>


### PR DESCRIPTION
## Summary
- 移除推广区 H2 与引用块，降低对 README 正文层级的干扰
- 使用居中信息层次和独立绿色 CTA 徽章聚焦注册入口
- 资料导航采用普通空格与中点分隔，允许窄屏自然折行

## Verification
- 临时 RED/GREEN 断言覆盖结构、核心文案与 5 个目标链接
- GitHub GFM API 渲染通过；Shields 徽章返回 HTTP 200 SVG
- GitHub 实际页面在 1440px、390px、320px 下通过 Chrome 验证：无横向溢出，徽章加载完成，320px 导航自然折行
- git diff --check 通过；最终 diff 仅 README.md

Closes SKZ-506